### PR TITLE
add a message to the main exception

### DIFF
--- a/oz-customize
+++ b/oz-customize
@@ -97,7 +97,10 @@ if os.access(config_file, os.F_OK):
 
 try:
     guest = oz.GuestFactory.guest_factory(tdl, config, None)
-except oz.OzException.OzException:
+except oz.OzException.OzException as message:
+    print ""
+    print "   Error customizing: " + str(message)
+    print ""
     usage()
 
 # Arbitrarily limit the size of the XML file that we will support to 5MB.

--- a/oz-generate-icicle
+++ b/oz-generate-icicle
@@ -97,7 +97,10 @@ if os.access(config_file, os.F_OK):
 
 try:
     guest = oz.GuestFactory.guest_factory(tdl, config, None)
-except oz.OzException.OzException:
+except oz.OzException.OzException as message:
+    print ""
+    print "   Error generating: " + str(message)
+    print ""
     usage()
 
 # Arbitrarily limit the size of the XML file that we will support to 5MB.

--- a/oz-install
+++ b/oz-install
@@ -122,7 +122,10 @@ if os.access(config_file, os.F_OK):
 
 try:
     guest = oz.GuestFactory.guest_factory(tdl, config, auto)
-except oz.OzException.OzException:
+except oz.OzException.OzException as message:
+    print ""
+    print "   Error installing: " + str(message)
+    print ""
     usage()
 
 if cleanup:


### PR DESCRIPTION
Hi Chris

This helps diagnose an error. Without it I didn't know what was going on.

Btw I now get:

sudo ./oz-install ./examples/f14x86_64.tdl

   Error installing: Default libvirt network (virbr0) does not exist, install cannot continue

I have a custom virt network setup.
ifconfig | grep virbr
virbr1    Link encap:Ethernet  HWaddr FE:54:00:7D:34:BC  
virbr2    Link encap:Ethernet  HWaddr 1A:B2:C0:6C:DD:EE

I have now renamed these in /etc/libvirt/qemu/networks/

-Angus
