### PR TITLE
concurrent installs freezes at guestfs kill_subprocess

### DIFF
--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -905,9 +905,6 @@ class Guest(object):
         self.log.debug("Unmounting all")
         g_handle.umount_all()
 
-        self.log.debug("Killing guestfs subprocess")
-        g_handle.kill_subprocess()
-
     def _modify_libvirt_xml_for_serial(self, libvirt_xml):
         """
         Internal method to take input libvirt XML (which may have been provided


### PR DESCRIPTION
When two or more installs are started at the same time, they
eventually reach _guestfs_handle_cleanup and one of the processes
will appear to have died, but others will remain.

I commented out the g_handle.kill_subprocess line and that
seems to solve the problem. All installs are able to complete
if that line is removed.

I was testing this using the aeolus-image cli by kicking off two
builds one after the other: aeolus-image build --target rhevm
-- template test.tdl; aeolus-image build --target vsphere --template
test.tdl

I came across some documentation on the guestfs_kill_subprocess method
and it appears that it shouldn't be used at all.
http://libguestfs.org/guestfs.3.html

I don't know the entire history of this bit of code, so I'm submitting
this patch for review/consideration.
