### PR TITLE
add 'persisted', 'clientkey', and 'clientcert' under repository

### DIFF
--- a/docs/tdl.rng
+++ b/docs/tdl.rng
@@ -117,9 +117,18 @@
                   <element name='url'>
                     <text/>
                   </element>
+                  <element name='persisted'>
+                    <ref name='bool'/>
+                  </element>
                   <optional>
                     <element name='signed'>
                       <ref name='bool'/>
+                    </element>
+                    <element name='clientcert'>
+                      <ref name='cert'/>
+                    </element>
+                     <element name='clientkey'>
+                      <ref name='key'/>
                     </element>
                   </optional>
                 </interleave>
@@ -138,6 +147,16 @@
     <element name='url'>
       <text/>
     </element>
+  </define>
+
+  <define name='cert'>
+    <data type="string">
+    </data>
+  </define>
+
+  <define name='key'>
+    <data type="string">
+    </data>
   </define>
 
   <define name='iso'>


### PR DESCRIPTION
This is from a patch sent in to imagefactory for the xsd we used to generate some html documentation.  We will be removing the xsd from imagefactory to avoid confusion in the future.

This patch came to us from Dmitri Dolguikh dmitri@appliedlogic.ca

Signed-off-by: Steve Loranz sloranz@xanham.com
