### PR TITLE
Add support for 6.2

### DIFF
--- a/oz/RHEL_6.py
+++ b/oz/RHEL_6.py
@@ -53,5 +53,5 @@ def get_class(tdl, config, auto, output_disk=None):
     """
     Factory method for RHEL-6 installs.
     """
-    if tdl.update in ["0", "1"]:
+    if tdl.update in ["0", "1", "2"]:
         return RHEL6Guest(tdl, config, auto, output_disk)


### PR DESCRIPTION
RHEL 6.2 is expected to be available soon.  We'd like to have "support" (in the form of not erring out on a 6.2 version in the TDL) in anticipation of this release.
