### PR TITLE
Remove extra console in libvirt XML declaration

### DIFF
--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -360,9 +360,6 @@ class Guest(object):
 
         # create devices
         devices = domain.newChild(None, "devices", None)
-        # console
-        console = devices.newChild(None, "console", None)
-        console.setProp("device", "pty")
         # graphics
         graphics = devices.newChild(None, "graphics", None)
         graphics.setProp("port", "-1")


### PR DESCRIPTION
This is to enable Oz on libvirt 0.9.7 [BZ758561]

Fix provided by Steven Dake sdake@redhat.com

This looks like a bug that was harmless in earlier libvirt versions but now produces an error.

I have tested the update again Factory running on RHEL 6.1 and everything seems to work just fine.  (Including the serial port guest check in.)
