### PR TITLE
Change default screenshot_dir to avoid writing to /

### DIFF
--- a/man/oz-cleanup-cache.1
+++ b/man/oz-cleanup-cache.1
@@ -41,7 +41,7 @@ The configuration file should have the following form:
 [paths]
 output_dir = /var/lib/libvirt/images
 data_dir = /var/lib/oz
-screenshot_dir = .
+screenshot_dir = /tmp/oz-screenshots
 
 [libvirt]
 uri = qemu:///system

--- a/man/oz-customize.1
+++ b/man/oz-customize.1
@@ -53,7 +53,7 @@ The configuration file should have the following form:
 [paths]
 output_dir = /var/lib/libvirt/images
 data_dir = /var/lib/oz
-screenshot_dir = .
+screenshot_dir = /tmp/oz-screenshots
 
 [libvirt]
 uri = qemu:///system

--- a/man/oz-install.1
+++ b/man/oz-install.1
@@ -108,7 +108,7 @@ The configuration file should have the following form:
 [paths]
 output_dir = /var/lib/libvirt/images
 data_dir = /var/lib/oz
-screenshot_dir = .
+screenshot_dir = /tmp/oz-screenshots
 
 [libvirt]
 uri = qemu:///system

--- a/oz.cfg
+++ b/oz.cfg
@@ -1,7 +1,7 @@
 [paths]
 output_dir = /var/lib/libvirt/images
 data_dir = /var/lib/oz
-screenshot_dir = .
+screenshot_dir = /tmp/oz-screenshots
 
 [libvirt]
 uri = qemu:///system

--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -790,6 +790,13 @@ class Guest(object):
         vnc = "localhost:%s" % (int(port) - 5900)
 
         try:
+            if not os.path.isdir(self.screenshot_dir):
+                self.mkdir_p(self.screenshot_dir)
+        except OSError, e:
+            self.log.error("Failed create screenshot directory - %s" % e)
+            return None
+
+        try:
             oz.ozutil.subprocess_check_output(['gvnccapture', vnc, screenshot])
             return screenshot
         except:


### PR DESCRIPTION
The current default screenshot_dir value of '.' results in screenshots
being written to the root directory.

> OzException: No disk activity in 300 seconds, failing.  Check screenshot
> at /client-a14da48d-ef38-485a-afb7-56f69597d553-1326467720.58.png for
> more detail

This patch changes the default to '/tmp/oz-screenshots' and creates the
directory if needed while saving a screenshot.
