### PR TITLE
fix concurrency bug in _guestfs_handle_setup

### DIFF
--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -821,7 +821,11 @@ class Guest(object):
             raise oz.OzException.OzException("invalid <disk> entry without a driver")
 
         for domid in self.libvirt_conn.listDomainsID():
-            doc = libxml2.parseDoc(self.libvirt_conn.lookupByID(domid).XMLDesc(0))
+            try:
+                doc = libxml2.parseDoc(self.libvirt_conn.lookupByID(domid).XMLDesc(0))
+            except:
+                self.log.debug("Could not get XML for domain ID (%s) - assuming it has been deleted" % (domid))
+                continue
             namenode = doc.xpathEval('/domain/name')
             if len(namenode) != 1:
                 # hm, odd, a domain without a name?


### PR DESCRIPTION
The code in question breaks if a VM is destroyed while the method
is running.  This can easily happen when doing multiple Oz based
builds concurrently and could also happen in the normal course
of events on a multiuser KVM host.

Deal with this situation gracefully.
