### PR TITLE
udpate debian packaging to more modern standards

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,21 +1,19 @@
 Source: oz
-Section: utils
-Priority: extra
 Maintainer: Richard Jones <rjones@redhat.com>
-Build-Depends: debhelper (>= 7.0.50~), cdbs (>=0.4.90~),
- python-all (>= 2.6.6-3~)
+Section: python
+Priority: optional
+Build-Depends: debhelper (>= 7.4.3), python-all (>= 2.6.6-3)
 Standards-Version: 3.8.4
 Homepage: http://aeolusproject.org/oz.html
 Vcs-Git: git://github.com/clalancette/oz.git
-#Vcs-Browser: http://git.debian.org/?p=collab-maint/oz.git;a=summary
-X-Python-Version: ${python:Versions}
+X-Python-Version: >= 2.6
 
 Package: oz
 Architecture: all
 Depends: ${misc:Depends}, ${python:Depends},
  python (>= 2.5),
- genisoimage,
 # for gvnccapture, but only packaged in Sid:
+ genisoimage,
  gvncviewer,
  libvirt-dev,
  mtools,
@@ -27,6 +25,6 @@ Depends: ${misc:Depends}, ${python:Depends},
  python-numpy,
  python-m2crypto,
  python-parted
-Description: Installing guest OSs with only minimal input the user
+Description: installing guest OSs with only minimal input the user
  Oz is a tool for automatically installing guest OSs with only minimal
  up-front input from the user.

--- a/debian/dirs
+++ b/debian/dirs
@@ -1,0 +1,8 @@
+etc/oz
+var/lib/oz/isocontent
+var/lib/oz/isos
+var/lib/oz/floppycontent
+var/lib/oz/floppies
+var/lib/oz/icicletmp
+var/lib/oz/jeos
+var/lib/oz/kernels

--- a/debian/install
+++ b/debian/install
@@ -1,0 +1,1 @@
+/oz.cfg etc/oz

--- a/debian/rules
+++ b/debian/rules
@@ -1,18 +1,4 @@
 #!/usr/bin/make -f
 
-DEB_PYTHON2_MODULE_PACKAGES=oz
-
-include /usr/share/cdbs/1/rules/debhelper.mk
-include /usr/share/cdbs/1/class/python-distutils.mk
-
-# Add here any variable or target overrides you need.
-install/oz::
-	mkdir -p debian/oz/var/lib/oz/isocontent/
-	mkdir -p debian/oz/var/lib/oz/isos/
-	mkdir -p debian/oz/var/lib/oz/floppycontent/
-	mkdir -p debian/oz/var/lib/oz/floppies/
-	mkdir -p debian/oz/var/lib/oz/icicletmp/
-	mkdir -p debian/oz/var/lib/oz/jeos/
-	mkdir -p debian/oz/var/lib/oz/kernels/
-	mkdir -p debian/oz/etc/oz
-	install -m 0644 oz.cfg debian/oz/etc/oz/
+%:
+	dh $@ --buildsystem=python_distutils --with=python2


### PR DESCRIPTION
add dirs file to create directories as per packaging guidelines
add install file to install configuration oz.cfg file into configuration
update control to match latest standards and pckage requirements
update rules to remove cdbs and only use dh

Signed-off-by: Steven Dake sdake@redhat.com
