### PR TITLE
Fix virtualenv and conditionally correct for paths with :space:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,12 +37,13 @@ man2html: examples-manpage
 	done
 
 $(VENV_DIR):
-	@virtualenv $(VENV_DIR)
+	@virtualenv --system-site-packages $(VENV_DIR)
 	@pip-python -E $(VENV_DIR) install pytest
-	@echo "Resolving potential problems where \$PWD contains spaces"
-	@for MATCH in $$(grep '^#!"/' $(VENV_DIR)/bin/* -l) ; do \
+	@[[ "$$PWD" =~ \ |\' ]] && ( \
+	echo "Resolving potential problems where '$$PWD' contains spaces" ; \
+	for MATCH in $$(grep '^#!"/' $(VENV_DIR)/bin/* -l) ; do \
 		sed -i '1s|^#!".*/\([^/]*\)"|#!/usr/bin/env \1|' "$$MATCH" ; \
-	done
+	done ) || true
 
 virtualenv: $(VENV_DIR)
 


### PR DESCRIPTION
Just a small set of changes to make virtualenv work again.  The virtualenv setup requires an additional argument.  I also added a conditional check around the existing logic that corrects for paths that contain a :space:.

Thanks,
James
