### PR TITLE
Add '--force-virtio' parameter to oz-install

### DIFF
--- a/man/oz-install.1
+++ b/man/oz-install.1
@@ -93,6 +93,12 @@ This timer value is not configurable.
 Customize the image after installation.  This generally installs
 additional packages onto the disk image after installation.
 .TP
+.B "\-v"
+Force the use of virtio devices. By default, each guest type is
+responsible of determining the type of the devices to be used. This
+option allows users to take advantage of virtio drivers with OS images
+that weren't expected to be supported.
+.TP
 .B "\-x <xmlfile>"
 Oz will normally generate a libvirt XML file in the current working
 directory suffixed with the date and time.  Specifying the \-x option

--- a/oz-install
+++ b/oz-install
@@ -47,6 +47,7 @@ def usage():
     print("  -s <disk>\tWrite the output to <disk> (default is the TDL name tag)")
     print("  -t <timeout>\tWait <timeout> seconds for installation, rather than the default")
     print("  -u\t\tAfter installation, do the customization")
+    print("  -v\t\tForce use of virtio devices")
     print("  -x <xmlfile>\tWrite libvirt XML to <xmlfile>")
     print(" Currently supported architectures are:")
     print("   i386, x86_64")
@@ -55,11 +56,11 @@ def usage():
     sys.exit(1)
 
 try:
-    opts, args = getopt.gnu_getopt(sys.argv[1:], 'a:c:d:fghi:ps:t:ux:',
+    opts, args = getopt.gnu_getopt(sys.argv[1:], 'a:c:d:fghi:ps:t:uvx:',
                                    ['auto', 'config', 'debug', 'force-download',
                                     'generate-icicle', 'help', 'icicle',
                                     'cleanup', 'disk', 'timeout', 'customize',
-                                    'xmlfile'])
+                                    'force-virtio', 'xmlfile'])
 except getopt.GetoptError as err:
     print(str(err))
     usage()
@@ -76,6 +77,7 @@ auto = None
 timeout = None
 icicle_file = None
 output_disk = None
+force_virtio = False
 for o, a in opts:
     if o in ("-a", "--auto"):
         auto = a
@@ -115,6 +117,8 @@ for o, a in opts:
         customize = True
     elif o in ("-x", "--xmlfile"):
         filename = a
+    elif o in ("-v", "--force-virtio"):
+        force_virtio = True
     else:
         assert False, "unhandled option"
 
@@ -143,7 +147,7 @@ try:
         guest.generate_install_media(force_download)
         try:
             guest.generate_diskimage(size=guest.disksize, force=force_download)
-            libvirt_xml = guest.install(timeout, force_download)
+            libvirt_xml = guest.install(timeout, force_download, force_virtio)
         except:
             guest.cleanup_old_guest()
             raise

--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -1527,10 +1527,13 @@ class CDGuest(Guest):
         out.write(eltoritodata)
         out.close()
 
-    def _do_install(self, timeout=None, force=False, reboots=0, cmdline=None):
+    def _do_install(self, timeout=None, force=False, reboots=0, cmdline=None, force_virtio=False):
         """
         Internal method to actually run the installation.
         """
+        if force_virtio:
+           self.disk_bus = "virtio"
+           self.nicmodel = "virtio"
         if not force and os.access(self.jeos_filename, os.F_OK):
             self.log.info("Found cached JEOS, using it")
             oz.ozutil.copyfile_sparse(self.jeos_filename, self.diskimage)
@@ -1571,11 +1574,11 @@ class CDGuest(Guest):
 
         return self._generate_xml("hd", None)
 
-    def install(self, timeout=None, force=False):
+    def install(self, timeout=None, force=False, force_virtio=False):
         """
         Method to run the operating system installation.
         """
-        return self._do_install(timeout, force, 0)
+        return self._do_install(timeout, force, 0, force_virtio)
 
     def _check_pvd(self):
         """
@@ -1720,10 +1723,14 @@ class FDGuest(Guest):
         self.log.info("Copying floppy contents for modification")
         shutil.copyfile(self.orig_floppy, self.output_floppy)
 
-    def install(self, timeout=None, force=False):
+    def install(self, timeout=None, force=False, force_virtio=False):
         """
         Method to run the operating system installation.
         """
+        if force_virtio:
+            self.disk_bus = "virtio"
+            self.nicmodel = "virtio"
+
         if not force and os.access(self.jeos_filename, os.F_OK):
             self.log.info("Found cached JEOS, using it")
             oz.ozutil.copyfile_sparse(self.jeos_filename, self.diskimage)

--- a/oz/Mandrake.py
+++ b/oz/Mandrake.py
@@ -158,11 +158,11 @@ class Mandrake82Guest(oz.Guest.CDGuest):
                                            "-v", "-v", "-o", self.output_iso,
                                            self.iso_contents])
 
-    def install(self, timeout=None, force=False):
+    def install(self, timeout=None, force=False, force_virtio=False):
         internal_timeout = timeout
         if internal_timeout is None:
             internal_timeout = 2500
-        return self._do_install(internal_timeout, force, 0)
+        return self._do_install(internal_timeout, force, 0, force_virtio)
 
 def get_class(tdl, config, auto, output_disk=None):
     """

--- a/oz/OpenSUSE.py
+++ b/oz/OpenSUSE.py
@@ -104,11 +104,11 @@ class OpenSUSEGuest(oz.Guest.CDGuest):
                                            "-o", self.output_iso,
                                            self.iso_contents])
 
-    def install(self, timeout=None, force=False):
+    def install(self, timeout=None, force=False, force_virtio=False):
         """
         Method to run the operating system installation.
         """
-        return self._do_install(timeout, force, self.reboots)
+        return self._do_install(timeout, force, self.reboots, force_virtio)
 
     def _shutdown_guest(self, guestaddr, libvirt_dom):
         """

--- a/oz/Ubuntu.py
+++ b/oz/Ubuntu.py
@@ -174,14 +174,14 @@ Subsystem       sftp    /usr/libexec/openssh/sftp-server
                                            "-v", "-v", "-o", self.output_iso,
                                            self.iso_contents])
 
-    def install(self, timeout=None, force=False):
+    def install(self, timeout=None, force=False, force_virtio=False):
         """
         Method to run the operating system installation.
         """
         if self.tdl.update in ["6.06", "6.10", "7.04"]:
             if not timeout:
                 timeout = 3000
-        return self._do_install(timeout, force, 0, self.cmdline)
+        return self._do_install(timeout, force, 0, self.cmdline, force_virtio)
 
     def _get_default_runlevel(self, g_handle):
         """

--- a/oz/Windows.py
+++ b/oz/Windows.py
@@ -136,14 +136,14 @@ class Windows2000andXPand2003(Windows):
             # choices; the user gets to keep both pieces if something breaks
             shutil.copy(self.siffile, outname)
 
-    def install(self, timeout=None, force=False):
+    def install(self, timeout=None, force=False, force_virtio=False):
         """
         Method to run the operating system installation.
         """
         internal_timeout = timeout
         if internal_timeout is None:
             internal_timeout = 3600
-        return self._do_install(internal_timeout, force, 1)
+        return self._do_install(internal_timeout, force, 1, force_virtio)
 
 class Windows2008and7(Windows):
     """
@@ -215,11 +215,11 @@ class Windows2008and7(Windows):
             # breaks
             shutil.copy(self.unattendfile, outname)
 
-    def install(self, timeout=None, force=False):
+    def install(self, timeout=None, force=False, force_virtio=False):
         internal_timeout = timeout
         if internal_timeout is None:
             internal_timeout = 6000
-        return self._do_install(internal_timeout, force, 2)
+        return self._do_install(internal_timeout, force, 2, force_virtio)
 
 def get_class(tdl, config, auto, output_disk=None):
     """


### PR DESCRIPTION
Hi Chris,

As we discussed previously on aeolus-devel, I'd find interesting to have the possibility of forcing Oz to use virtio drivers.

This allows users to take advantage of virtio with guests that weren't expected to be supported by virtio drivers. In this case, it's responsibility of the user to provide the adequate OS images.

I know you're busy these days, but I think it's easy to keep track of the proposal through github rather than the mailing list, isn't it?

Thanks :)
