### PR TITLE
In Ubuntu 12.10 apt-add-repository got moved to software-properties-common

### DIFF
--- a/oz/auto/ubuntu-12.10-jeos.preseed
+++ b/oz/auto/ubuntu-12.10-jeos.preseed
@@ -24,7 +24,7 @@ d-i passwd/root-password-again password %ROOTPW%
 
 tasksel tasksel/first multiselect standard
 d-i     pkgsel/include/install-recommends       boolean true
-d-i     pkgsel/include  string openssh-server python-software-properties
+d-i     pkgsel/include  string openssh-server python-software-properties software-properties-common
 
 d-i grub-installer/only_debian boolean true
 d-i grub-installer/with_other_os boolean true


### PR DESCRIPTION
See https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/1021418 for information.

The changelog for the quantal python-software-properties http://changelogs.ubuntu.com/changelogs/pool/main/s/software-properties/software-properties_0.92.9/changelog - 0.85 and 0.84 is where the magic happened
