### PR TITLE
Quote apt-add-repository arguments to allow for non-ppa inputs

### DIFF
--- a/oz/Ubuntu.py
+++ b/oz/Ubuntu.py
@@ -449,7 +449,7 @@ Subsystem       sftp    /usr/libexec/openssh/sftp-server
         self.log.debug("Installing additional repository files")
 
         for repo in list(self.tdl.repositories.values()):
-            self.guest_execute_command(guestaddr, "apt-add-repository %s" % (repo.url))
+            self.guest_execute_command(guestaddr, "apt-add-repository '%s'" % (repo.url.strip('\'"'))
             self.guest_execute_command(guestaddr, "apt-get update")
 
     def do_customize(self, guestaddr):


### PR DESCRIPTION
This allows for `deb http://example.com foo main` type of input. apt-add-repository requires it to be quoted. A PPA input can also be quoted without problems.
The commit allows people to add the `deb` bit to the TDL without having to add in the extra quotes around it in there.

Note: This would break things for people that have already used quotes in their TDL - That's why the strip() call is there
