### PR TITLE
Support url based installs for Ubuntu

### DIFF
--- a/oz/Ubuntu.py
+++ b/oz/Ubuntu.py
@@ -31,7 +31,7 @@ import oz.OzException
 
 class UbuntuGuest(oz.Guest.CDGuest):
     """
-    Class for Ubuntu 6.06, 6.10, 7.04, 7.10, 8.04, 8.10, 9.04, 9.10, 10.04, 10.10, 11.04, 11.10, 12.04, and 12.10 installation.
+    Class for Ubuntu 6.06, 6.10, 7.04, 7.10, 8.04, 8.10, 9.04, 9.10, 10.04, 10.10, 11.04, 11.10, 12.04, 12.10, 13.04 installation.
     """
     def __init__(self, tdl, config, auto, output_disk, initrd, nicmodel,
                  diskbus):
@@ -39,9 +39,9 @@ class UbuntuGuest(oz.Guest.CDGuest):
             tdl.update = "6.06"
         elif tdl.update in ["8.04", "8.04.1", "8.04.2", "8.04.3", "8.04.4"]:
             tdl.update = "8.04"
-        elif tdl.update in ["10.04", "10.04.1", "10.04.2", "10.04.3"]:
+        elif tdl.update in ["10.04", "10.04.1", "10.04.2", "10.04.3", "10.04.4"]:
             tdl.update = "10.04"
-        elif tdl.update in ["12.04", "12.04.1"]:
+        elif tdl.update in ["12.04", "12.04.1", "12.04.2"]:
             tdl.update = "12.04"
 
         oz.Guest.CDGuest.__init__(self, tdl, config, output_disk, nicmodel,
@@ -805,8 +805,9 @@ def get_class(tdl, config, auto, output_disk=None):
                       "9.04"]:
         return UbuntuGuest(tdl, config, auto, output_disk, "initrd.gz",
                            "virtio", "virtio")
-    if tdl.update in ["9.10", "10.04", "10.04.1", "10.04.2", "10.04.3", "10.10",
-                      "11.04", "11.10", "12.04", "12.04.1", "12.10"]:
+    if tdl.update in ["9.10", "10.04", "10.04.1", "10.04.2", "10.04.3",
+                      "10.04.4", "10.10", "11.04", "11.10", "12.04", "12.04.1",
+                      "12.04.2", "12.10", "13.04"]:
         return UbuntuGuest(tdl, config, auto, output_disk, "initrd.lz",
                            "virtio", "virtio")
 
@@ -814,4 +815,4 @@ def get_supported_string():
     """
     Return supported versions as a string.
     """
-    return "Ubuntu: 6.06[.1,.2], 6.10, 7.04, 7.10, 8.04[.1,.2,.3,.4], 8.10, 9.04, 9.10, 10.04[.1,.2,.3], 10.10, 11.04, 11.10, 12.04[.1], 12.10"
+    return "Ubuntu: 6.06[.1,.2], 6.10, 7.04, 7.10, 8.04[.1,.2,.3,.4], 8.10, 9.04, 9.10, 10.04[.1,.2,.3,.4], 10.10, 11.04, 11.10, 12.04[.1,.2], 12.10, 13.04"

--- a/tests/factory/test_factory.py
+++ b/tests/factory/test_factory.py
@@ -89,7 +89,7 @@ def runtest(args):
     global route
 
     (distro, version, arch, installtype) = args
-    print("Testing %s-%s-%s-%s..." % (distro, version, arch, installtype), end=' ')
+    print("Testing %s-%s-%s-%s..." % (distro, version, arch, installtype))
 
     tdlxml = """
 <template>
@@ -109,7 +109,7 @@ def runtest(args):
     tdl = oz.TDL.TDL(tdlxml)
 
     config = configparser.SafeConfigParser()
-    config.readfp(io.StringIO("[libvirt]\nuri=qemu:///session\nbridge_name=%s" % route))
+    config.readfp(io.StringIO(u"[libvirt]\nuri=qemu:///session\nbridge_name=%s" % route))
 
     if os.getenv('DEBUG') != None:
         logging.basicConfig(level=logging.DEBUG, format="%(message)s")
@@ -250,14 +250,14 @@ def test_all():
     # Ubuntu
     for version in ["6.06", "6.06.1", "6.06.2", "6.10", "7.04", "7.10", "8.04",
                     "8.04.1", "8.04.2", "8.04.3", "8.04.4", "8.10", "9.04",
-                    "9.10", "10.04", "10.04.1", "10.04.2", "10.04.3", "10.10",
-                    "11.04", "11.10"]:
+                    "9.10", "10.04", "10.04.1", "10.04.2", "10.04.3",
+                    "10.04.4", "10.10", "11.04", "11.10", "12.04", "12.04.1",
+                    "12.04.2", "12.10", "13.04"]:
         for arch in ["i386", "x86_64"]:
-            expect_success("Ubuntu", version, arch, "iso")
+            for installtype in ["url", "iso"]:
+                expect_success("Ubuntu", version, arch, installtype)
     # bad Ubuntu version
     expect_fail("Ubuntu", "10.9", "i386", "iso")
-    # bad Ubuntu installtype
-    expect_fail("Ubuntu", "10.10", "i386", "url")
 
     # Mandrake
     for version in ["8.2", "9.1", "9.2", "10.0", "10.1"]:

--- a/tests/guest/test_guest.py
+++ b/tests/guest/test_guest.py
@@ -74,7 +74,7 @@ def test_geteltorito_none_src():
     tdl = oz.TDL.TDL(tdlxml)
 
     config = configparser.SafeConfigParser()
-    config.readfp(io.StringIO("[libvirt]\nuri=qemu:///session\nbridge_name=%s" % route))
+    config.readfp(io.StringIO(u"[libvirt]\nuri=qemu:///session\nbridge_name=%s" % route))
 
     guest = oz.GuestFactory.guest_factory(tdl, config, None)
 
@@ -85,7 +85,7 @@ def test_geteltorito_none_dst(tmpdir):
     tdl = oz.TDL.TDL(tdlxml)
 
     config = configparser.SafeConfigParser()
-    config.readfp(io.StringIO("[libvirt]\nuri=qemu:///session\nbridge_name=%s" % route))
+    config.readfp(io.StringIO(u"[libvirt]\nuri=qemu:///session\nbridge_name=%s" % route))
 
     guest = oz.GuestFactory.guest_factory(tdl, config, None)
 
@@ -99,7 +99,7 @@ def test_geteltorito_short_pvd(tmpdir):
     tdl = oz.TDL.TDL(tdlxml)
 
     config = configparser.SafeConfigParser()
-    config.readfp(io.StringIO("[libvirt]\nuri=qemu:///session\nbridge_name=%s" % route))
+    config.readfp(io.StringIO(u"[libvirt]\nuri=qemu:///session\nbridge_name=%s" % route))
 
     guest = oz.GuestFactory.guest_factory(tdl, config, None)
 
@@ -115,7 +115,7 @@ def test_geteltorito_bogus_pvd_desc(tmpdir):
     tdl = oz.TDL.TDL(tdlxml)
 
     config = configparser.SafeConfigParser()
-    config.readfp(io.StringIO("[libvirt]\nuri=qemu:///session\nbridge_name=%s" % route))
+    config.readfp(io.StringIO(u"[libvirt]\nuri=qemu:///session\nbridge_name=%s" % route))
 
     guest = oz.GuestFactory.guest_factory(tdl, config, None)
 
@@ -134,7 +134,7 @@ def test_geteltorito_bogus_pvd_ident(tmpdir):
     tdl = oz.TDL.TDL(tdlxml)
 
     config = configparser.SafeConfigParser()
-    config.readfp(io.StringIO("[libvirt]\nuri=qemu:///session\nbridge_name=%s" % route))
+    config.readfp(io.StringIO(u"[libvirt]\nuri=qemu:///session\nbridge_name=%s" % route))
 
     guest = oz.GuestFactory.guest_factory(tdl, config, None)
 
@@ -154,7 +154,7 @@ def test_geteltorito_bogus_pvd_unused(tmpdir):
     tdl = oz.TDL.TDL(tdlxml)
 
     config = configparser.SafeConfigParser()
-    config.readfp(io.StringIO("[libvirt]\nuri=qemu:///session\nbridge_name=%s" % route))
+    config.readfp(io.StringIO(u"[libvirt]\nuri=qemu:///session\nbridge_name=%s" % route))
 
     guest = oz.GuestFactory.guest_factory(tdl, config, None)
 
@@ -176,7 +176,7 @@ def test_geteltorito_bogus_pvd_unused2(tmpdir):
     tdl = oz.TDL.TDL(tdlxml)
 
     config = configparser.SafeConfigParser()
-    config.readfp(io.StringIO("[libvirt]\nuri=qemu:///session\nbridge_name=%s" % route))
+    config.readfp(io.StringIO(u"[libvirt]\nuri=qemu:///session\nbridge_name=%s" % route))
 
     guest = oz.GuestFactory.guest_factory(tdl, config, None)
 
@@ -202,7 +202,7 @@ def test_geteltorito_short_boot_sector(tmpdir):
     tdl = oz.TDL.TDL(tdlxml)
 
     config = configparser.SafeConfigParser()
-    config.readfp(io.StringIO("[libvirt]\nuri=qemu:///session\nbridge_name=%s" % route))
+    config.readfp(io.StringIO(u"[libvirt]\nuri=qemu:///session\nbridge_name=%s" % route))
 
     guest = oz.GuestFactory.guest_factory(tdl, config, None)
 
@@ -228,7 +228,7 @@ def test_geteltorito_bogus_boot_sector(tmpdir):
     tdl = oz.TDL.TDL(tdlxml)
 
     config = configparser.SafeConfigParser()
-    config.readfp(io.StringIO("[libvirt]\nuri=qemu:///session\nbridge_name=%s" % route))
+    config.readfp(io.StringIO(u"[libvirt]\nuri=qemu:///session\nbridge_name=%s" % route))
 
     guest = oz.GuestFactory.guest_factory(tdl, config, None)
 
@@ -257,7 +257,7 @@ def test_geteltorito_bogus_boot_isoident(tmpdir):
     tdl = oz.TDL.TDL(tdlxml)
 
     config = configparser.SafeConfigParser()
-    config.readfp(io.StringIO("[libvirt]\nuri=qemu:///session\nbridge_name=%s" % route))
+    config.readfp(io.StringIO(u"[libvirt]\nuri=qemu:///session\nbridge_name=%s" % route))
 
     guest = oz.GuestFactory.guest_factory(tdl, config, None)
 
@@ -287,7 +287,7 @@ def test_geteltorito_bogus_boot_version(tmpdir):
     tdl = oz.TDL.TDL(tdlxml)
 
     config = configparser.SafeConfigParser()
-    config.readfp(io.StringIO("[libvirt]\nuri=qemu:///session\nbridge_name=%s" % route))
+    config.readfp(io.StringIO(u"[libvirt]\nuri=qemu:///session\nbridge_name=%s" % route))
 
     guest = oz.GuestFactory.guest_factory(tdl, config, None)
 
@@ -317,7 +317,7 @@ def test_geteltorito_bogus_boot_torito(tmpdir):
     tdl = oz.TDL.TDL(tdlxml)
 
     config = configparser.SafeConfigParser()
-    config.readfp(io.StringIO("[libvirt]\nuri=qemu:///session\nbridge_name=%s" % route))
+    config.readfp(io.StringIO(u"[libvirt]\nuri=qemu:///session\nbridge_name=%s" % route))
 
     guest = oz.GuestFactory.guest_factory(tdl, config, None)
 
@@ -348,7 +348,7 @@ def test_geteltorito_bogus_bootp(tmpdir):
     tdl = oz.TDL.TDL(tdlxml)
 
     config = configparser.SafeConfigParser()
-    config.readfp(io.StringIO("[libvirt]\nuri=qemu:///session\nbridge_name=%s" % route))
+    config.readfp(io.StringIO(u"[libvirt]\nuri=qemu:///session\nbridge_name=%s" % route))
 
     guest = oz.GuestFactory.guest_factory(tdl, config, None)
 


### PR DESCRIPTION
- copy/modify code for RedHat url based installs to Ubuntu
- modify UbuntuGuest for required attributes
- read grub configs for needed kernel/initrd information
- workarounds for different layout on `mini.iso` vs. standard Ubuntu images

Valid `<url>` values for Ubuntu installs
- [Updated Precise amd64](http://archive.ubuntu.com/ubuntu/dists/precise-updates/main/installer-amd64/current/images/netboot/)
- [Original release Quantal i386](http://archive.ubuntu.com/ubuntu/dists/quantal/main/installer-i386/current/images/netboot/)
