### PR TITLE
Added ability to create qcow2 images

### DIFF
--- a/oz.cfg
+++ b/oz.cfg
@@ -5,6 +5,7 @@ screenshot_dir = /var/lib/oz/screenshots
 
 [libvirt]
 uri = qemu:///system
+image_type = raw
 # type = kvm
 # bridge_name = virbr0
 # cpus = 1


### PR DESCRIPTION
I added another configuration parameter under libvirt.  It is called image_type.  The two possible values are 'raw' and 'qcow2'.  The default is 'raw'.   

When image_type is 'qcow2', oz generate a qcow2 image.  

When image_type is 'raw', oz retains old behavior and creates a raw image.
