### PR TITLE
Allow configuration to override the command used to generate ICICLE on R...

### DIFF
--- a/oz/RedHat.py
+++ b/oz/RedHat.py
@@ -462,8 +462,13 @@ Subsystem	sftp	/usr/libexec/openssh/sftp-server
         Method to collect the package information and generate the ICICLE
         XML.
         """
+
+        icicle_cmd = oz.ozutil.config_get_key(config, 'redhat',
+                                              'icicle_command',
+                                              'rpm -qa')
+
         stdout, stderr, retcode = self.guest_execute_command(guestaddr,
-                                                             'rpm -qa',
+                                                             icicle_cmd,
                                                              timeout=30)
 
         return self._output_icicle_xml(stdout.split("\n"),


### PR DESCRIPTION
...ed Hat OSes

The default behavior with the default config file remains "rpm -qa"

This is to help with some work we are doing to integrate Oz/ImageFactory image
generation into koji.  The specific addition we made to the config file in this
case is:

[redhat]
icicle_command = "rpm -qa --qf '%%{NAME},%%{VERSION},%%{RELEASE},%%{ARCH},%%{EPOCH},%%{SIZE},%%{SIGMD5},%%{BUILDTIME}\n'"

Note that the extra %s are because SafeConfigParser treats % as a special character
which needs to be esacped by doubling it.
