### PR TITLE
Clean up imports and various other smaller items

### DIFF
--- a/oz/Fedora.py
+++ b/oz/Fedora.py
@@ -20,10 +20,7 @@ Fedora installation
 """
 
 import os
-
-import oz.ozutil
 import oz.RedHat
-import oz.OzException
 
 class FedoraGuest(oz.RedHat.RedHatCDYumGuest):
     """

--- a/oz/FedoraCore.py
+++ b/oz/FedoraCore.py
@@ -19,10 +19,7 @@ Fedora Core installation
 """
 
 import os
-
-import oz.ozutil
 import oz.RedHat
-import oz.OzException
 
 class FedoraCoreGuest(oz.RedHat.RedHatCDGuest):
     """

--- a/oz/GuestFactory.py
+++ b/oz/GuestFactory.py
@@ -19,7 +19,7 @@
 Factory functions.
 """
 
-import oz.OzException
+from oz.OzException import OzException
 
 os_dict = { 'Fedora': 'Fedora',
             'FedoraCore': 'FedoraCore',
@@ -84,7 +84,7 @@ def guest_factory(tdl, config, auto, output_disk=None):
             break
 
     if klass is None:
-        raise oz.OzException.OzException("Unsupported " + tdl.distro + " update " + tdl.update)
+        raise OzException("Unsupported " + tdl.distro + " update " + tdl.update)
 
     return klass
 

--- a/oz/Mandrake.py
+++ b/oz/Mandrake.py
@@ -19,12 +19,12 @@ Mandrake installation
 """
 
 import shutil
-import os
 import re
+from os.path import join
 
 import oz.Guest
-import oz.ozutil
-import oz.OzException
+from oz.ozutil import generate_full_auto_path, copy_modify_file, subprocess_check_output
+from oz.OzException import OzException
 
 class MandrakeGuest(oz.Guest.CDGuest):
     """
@@ -35,23 +35,22 @@ class MandrakeGuest(oz.Guest.CDGuest):
                                   None, None, None, True, False)
 
         if self.tdl.arch != "i386":
-            raise oz.OzException.OzException("Mandrake only supports i386 architecture")
+            raise OzException("Mandrake only supports i386 architecture")
 
         self.auto = auto
         if self.auto is None:
-            self.auto = oz.ozutil.generate_full_auto_path("mandrake-" + self.tdl.update + "-jeos.cfg")
+            self.auto = generate_full_auto_path("mandrake-" + self.tdl.update + "-jeos.cfg")
 
     def _modify_iso(self):
         """
         Method to make the boot ISO auto-boot with appropriate parameters.
         """
         self.log.debug("Modifying ISO")
-
         self.log.debug("Copying cfg file")
 
-        outname = os.path.join(self.iso_contents, "auto_inst.cfg")
+        outname = join(self.iso_contents, "auto_inst.cfg")
 
-        if self.auto == oz.ozutil.generate_full_auto_path("mandrake-" + self.tdl.update + "-jeos.cfg"):
+        if self.auto == generate_full_auto_path("mandrake-" + self.tdl.update + "-jeos.cfg"):
 
             def _cfg_sub(line):
                 """
@@ -63,35 +62,35 @@ class MandrakeGuest(oz.Guest.CDGuest):
                 else:
                     return line
 
-            oz.ozutil.copy_modify_file(self.auto, outname, _cfg_sub)
+            copy_modify_file(self.auto, outname, _cfg_sub)
         else:
             shutil.copy(self.auto, outname)
 
         self.log.debug("Modifying isolinux.cfg")
-        isolinuxcfg = os.path.join(self.iso_contents, "isolinux",
-                                   "isolinux.cfg")
-        f = open(isolinuxcfg, 'w')
-        f.write("default customiso\n")
-        f.write("timeout 1\n")
-        f.write("prompt 0\n")
-        f.write("label customiso\n")
-        f.write("  kernel alt0/vmlinuz\n")
-        f.write("  append initrd=alt0/all.rdz ramdisk_size=128000 root=/dev/ram3 acpi=ht vga=788 automatic=method:cdrom kickstart=auto_inst.cfg\n")
-        f.close()
+        isolinuxcfg = join(self.iso_contents, "isolinux", "isolinux.cfg")
+        with open(isolinuxcfg, 'w') as f:
+            f.write("""\
+default customiso
+timeout 1
+prompt 0
+label customiso
+  kernel alt0/vmlinuz
+  append initrd=alt0/all.rdz ramdisk_size=128000 root=/dev/ram3 acpi=ht vga=788 automatic=method:cdrom kickstart=auto_inst.cfg
+""")
 
     def _generate_new_iso(self):
         """
         Method to create a new ISO based on the modified CD/DVD.
         """
         self.log.info("Generating new ISO")
-        oz.ozutil.subprocess_check_output(["genisoimage", "-r", "-V", "Custom",
-                                           "-J", "-l", "-no-emul-boot",
-                                           "-b", "isolinux/isolinux.bin",
-                                           "-c", "isolinux/boot.cat",
-                                           "-boot-load-size", "4",
-                                           "-cache-inodes", "-boot-info-table",
-                                           "-v", "-v", "-o", self.output_iso,
-                                           self.iso_contents])
+        subprocess_check_output(["genisoimage", "-r", "-V", "Custom",
+                                 "-J", "-l", "-no-emul-boot",
+                                 "-b", "isolinux/isolinux.bin",
+                                 "-c", "isolinux/boot.cat",
+                                 "-boot-load-size", "4",
+                                 "-cache-inodes", "-boot-info-table",
+                                 "-v", "-v", "-o", self.output_iso,
+                                 self.iso_contents])
 
 class Mandrake82Guest(oz.Guest.CDGuest):
     """
@@ -102,11 +101,11 @@ class Mandrake82Guest(oz.Guest.CDGuest):
                                   None, None, None, True, False)
 
         if self.tdl.arch != "i386":
-            raise oz.OzException.OzException("Mandrake only supports i386 architecture")
+            raise OzException("Mandrake only supports i386 architecture")
 
         self.auto = auto
         if self.auto is None:
-            self.auto = oz.ozutil.generate_full_auto_path("mandrake-" + self.tdl.update + "-jeos.cfg")
+            self.auto = generate_full_auto_path("mandrake-" + self.tdl.update + "-jeos.cfg")
 
     def _modify_iso(self):
         """
@@ -114,8 +113,8 @@ class Mandrake82Guest(oz.Guest.CDGuest):
         """
         self.log.debug("Modifying ISO")
 
-        outname = os.path.join(self.iso_contents, "auto_inst.cfg")
-        if self.auto == oz.ozutil.generate_full_auto_path("mandrake-" + self.tdl.update + "-jeos.cfg"):
+        outname = join(self.iso_contents, "auto_inst.cfg")
+        if self.auto == generate_full_auto_path("mandrake-" + self.tdl.update + "-jeos.cfg"):
 
             def _cfg_sub(line):
                 """
@@ -127,36 +126,35 @@ class Mandrake82Guest(oz.Guest.CDGuest):
                 else:
                     return line
 
-            oz.ozutil.copy_modify_file(self.auto, outname, _cfg_sub)
+            copy_modify_file(self.auto, outname, _cfg_sub)
         else:
             shutil.copy(self.auto, outname)
 
-        syslinux = os.path.join(self.icicle_tmp, 'syslinux.cfg')
-        f = open(syslinux, 'w')
-        f.write("default customiso\n")
-        f.write("timeout 1\n")
-        f.write("prompt 0\n")
-        f.write("label customiso\n")
-        f.write("  kernel vmlinuz\n")
-        f.write("  append initrd=cdrom.rdz ramdisk_size=32000 root=/dev/ram3 automatic=method:cdrom vga=788 auto_install=auto_inst.cfg\n")
-        f.close()
+        syslinux = join(self.icicle_tmp, 'syslinux.cfg')
+        with open(syslinux, 'w') as f:
+            f.write("""\
+default customiso
+timeout 1
+prompt 0
+label customiso
+  kernel vmlinuz
+  append initrd=cdrom.rdz ramdisk_size=32000 root=/dev/ram3 automatic=method:cdrom vga=788 auto_install=auto_inst.cfg
+""")
 
-        cdromimg = os.path.join(self.iso_contents, "Boot", "cdrom.img")
-        oz.ozutil.subprocess_check_output(["mcopy", "-n", "-o", "-i",
-                                           cdromimg, syslinux,
-                                           "::SYSLINUX.CFG"])
+        cdromimg = join(self.iso_contents, "Boot", "cdrom.img")
+        subprocess_check_output(["mcopy", "-n", "-o", "-i", cdromimg, syslinux, "::SYSLINUX.CFG"])
 
     def _generate_new_iso(self):
         """
         Method to create a new ISO based on the modified CD/DVD.
         """
         self.log.info("Generating new ISO")
-        oz.ozutil.subprocess_check_output(["genisoimage", "-r", "-V", "Custom",
-                                           "-J", "-cache-inodes",
-                                           "-b", "Boot/cdrom.img",
-                                           "-c", "Boot/boot.cat",
-                                           "-v", "-v", "-o", self.output_iso,
-                                           self.iso_contents])
+        subprocess_check_output(["genisoimage", "-r", "-V", "Custom",
+                                "-J", "-cache-inodes",
+                                "-b", "Boot/cdrom.img",
+                                "-c", "Boot/boot.cat",
+                                "-v", "-v", "-o", self.output_iso,
+                                self.iso_contents])
 
     def install(self, timeout=None, force=False):
         internal_timeout = timeout

--- a/oz/OpenSUSE.py
+++ b/oz/OpenSUSE.py
@@ -21,13 +21,14 @@ OpenSUSE installation
 
 import re
 import shutil
-import os
 import libxml2
 import libvirt
+import os
+from os.path import join
 
 import oz.Guest
-import oz.ozutil
-import oz.OzException
+from oz.ozutil import generate_full_auto_path, copy_modify_file, subprocess_check_output, ssh_execute_command, scp_copy_file
+from oz.OzException import OzException
 
 class OpenSUSEGuest(oz.Guest.CDGuest):
     """
@@ -44,9 +45,9 @@ class OpenSUSEGuest(oz.Guest.CDGuest):
 
         self.autoyast = auto
         if self.autoyast is None:
-            self.autoyast = oz.ozutil.generate_full_auto_path("opensuse-" + self.tdl.update + "-jeos.xml")
+            self.autoyast = generate_full_auto_path("opensuse-" + self.tdl.update + "-jeos.xml")
 
-        self.sshprivkey = os.path.join('/etc', 'oz', 'id_rsa-icicle-gen')
+        self.sshprivkey = join('/etc', 'oz', 'id_rsa-icicle-gen')
 
     def _modify_iso(self):
         """
@@ -54,9 +55,9 @@ class OpenSUSEGuest(oz.Guest.CDGuest):
         """
         self.log.debug("Putting the autoyast in place")
 
-        outname = os.path.join(self.iso_contents, "autoinst.xml")
+        outname = join(self.iso_contents, "autoinst.xml")
 
-        if self.autoyast == oz.ozutil.generate_full_auto_path("opensuse-" + self.tdl.update + "-jeos.xml"):
+        if self.autoyast == generate_full_auto_path("opensuse-" + self.tdl.update + "-jeos.xml"):
             doc = libxml2.parseFile(self.autoyast)
 
             xp = doc.xpathNewContext()
@@ -70,8 +71,7 @@ class OpenSUSEGuest(oz.Guest.CDGuest):
             shutil.copy(self.autoyast, outname)
 
         self.log.debug("Modifying the boot options")
-        isolinux_cfg = os.path.join(self.iso_contents, "boot", self.tdl.arch,
-                                    "loader", "isolinux.cfg")
+        isolinux_cfg = join(self.iso_contents, "boot", self.tdl.arch, "loader", "isolinux.cfg")
         f = open(isolinux_cfg, "r")
         lines = f.readlines()
         f.close()
@@ -93,16 +93,16 @@ class OpenSUSEGuest(oz.Guest.CDGuest):
         Method to create a new ISO based on the modified CD/DVD.
         """
         self.log.info("Generating new ISO")
-        oz.ozutil.subprocess_check_output(["genisoimage", "-r", "-V", "Custom",
-                                           "-J", "-no-emul-boot",
-                                           "-b", "boot/" + self.tdl.arch + "/loader/isolinux.bin",
-                                           "-c", "boot/" + self.tdl.arch + "/loader/boot.cat",
-                                           "-boot-load-size", "4",
-                                           "-boot-info-table", "-graft-points",
-                                           "-iso-level", "4", "-pad",
-                                           "-allow-leading-dots", "-l",
-                                           "-o", self.output_iso,
-                                           self.iso_contents])
+        subprocess_check_output(["genisoimage", "-r", "-V", "Custom",
+                                 "-J", "-no-emul-boot",
+                                 "-b", "boot/" + self.tdl.arch + "/loader/isolinux.bin",
+                                 "-c", "boot/" + self.tdl.arch + "/loader/boot.cat",
+                                 "-boot-load-size", "4",
+                                 "-boot-info-table", "-graft-points",
+                                 "-iso-level", "4", "-pad",
+                                 "-allow-leading-dots", "-l",
+                                 "-o", self.output_iso,
+                                 self.iso_contents])
 
     def install(self, timeout=None, force=False):
         """
@@ -141,8 +141,7 @@ class OpenSUSEGuest(oz.Guest.CDGuest):
         """
         Method to execute a command on the guest and return the output.
         """
-        return oz.ozutil.ssh_execute_command(guestaddr, self.sshprivkey,
-                                             command, timeout)
+        return ssh_execute_command(guestaddr, self.sshprivkey, command, timeout)
 
     def _image_ssh_teardown_step_1(self, g_handle):
         """
@@ -270,11 +269,11 @@ class OpenSUSEGuest(oz.Guest.CDGuest):
         # part 2; check and setup sshd
         self.log.debug("Step 2: setup sshd")
         if not g_handle.exists('/etc/init.d/sshd') or not g_handle.exists('/usr/sbin/sshd'):
-            raise oz.OzException.OzException("ssh not installed on the image, cannot continue")
+            raise OzException("ssh not installed on the image, cannot continue")
 
         self._guestfs_path_backup(g_handle, "/etc/init.d/after.local")
 
-        local = os.path.join(self.icicle_tmp, "after.local")
+        local = join(self.icicle_tmp, "after.local")
         f = open(local, "w")
         f.write("/sbin/service sshd start\n")
         f.close()
@@ -315,9 +314,9 @@ AcceptEnv LC_IDENTIFICATION LC_ALL
         # part 3; make sure the guest announces itself
         self.log.debug("Step 3: Guest announcement")
         if not g_handle.exists('/etc/init.d/cron') or not g_handle.exists('/usr/sbin/cron'):
-            raise oz.OzException.OzException("cron not installed on the image, cannot continue")
+            raise OzException("cron not installed on the image, cannot continue")
 
-        scriptfile = os.path.join(self.icicle_tmp, "script")
+        scriptfile = join(self.icicle_tmp, "script")
         f = open(scriptfile, 'w')
         f.write("#!/bin/bash\n")
         f.write("DEV=$(/bin/awk '{if ($2 == 0) print $1}' /proc/net/route) &&\n")
@@ -332,7 +331,7 @@ AcceptEnv LC_IDENTIFICATION LC_ALL
         finally:
             os.unlink(scriptfile)
 
-        announcefile = os.path.join(self.icicle_tmp, "announce")
+        announcefile = join(self.icicle_tmp, "announce")
         f = open(announcefile, 'w')
         f.write('*/1 * * * * root /bin/bash -c "/root/reportip"\n')
         f.close()
@@ -396,8 +395,7 @@ AcceptEnv LC_IDENTIFICATION LC_ALL
         """
         Method to copy a file to the live guest.
         """
-        return oz.ozutil.scp_copy_file(guestaddr, self.sshprivkey,
-                                       file_to_upload, destination, timeout)
+        return scp_copy_file(guestaddr, self.sshprivkey, file_to_upload, destination, timeout)
 
     def _customize_files(self, guestaddr):
         """
@@ -405,7 +403,7 @@ AcceptEnv LC_IDENTIFICATION LC_ALL
         """
         self.log.info("Uploading custom files")
         for name, content in list(self.tdl.files.items()):
-            localname = os.path.join(self.icicle_tmp, "file")
+            localname = join(self.icicle_tmp, "file")
             f = open(localname, 'w')
             f.write(content)
             f.close()
@@ -478,7 +476,7 @@ AcceptEnv LC_IDENTIFICATION LC_ALL
                 count -= 1
 
         if not success:
-            raise oz.OzException.OzException("Failed to connect to ssh on running guest")
+            raise OzException("Failed to connect to ssh on running guest")
 
     def _internal_customize(self, libvirt_xml, action):
         """
@@ -524,7 +522,7 @@ AcceptEnv LC_IDENTIFICATION LC_ALL
                 elif action == "mod_only":
                     self.do_customize(guestaddr)
                 else:
-                    raise oz.OzException.OzException("Invalid customize action %s; this is a programming error" % (action))
+                    raise OzException("Invalid customize action %s; this is a programming error" % (action))
             finally:
                 self._shutdown_guest(guestaddr, libvirt_dom)
         finally:

--- a/oz/RHEL_2_1.py
+++ b/oz/RHEL_2_1.py
@@ -19,7 +19,6 @@ RHEL-2.1 installation
 """
 
 import oz.RedHat
-import oz.OzException
 
 class RHEL21Guest(oz.RedHat.RedHatFDGuest):
     """

--- a/oz/RHEL_3.py
+++ b/oz/RHEL_3.py
@@ -19,11 +19,10 @@ RHEL-3 installation
 """
 
 import re
-import os
+from os.path import join
 
-import oz.ozutil
 import oz.RedHat
-import oz.OzException
+from oz.OzException import OzException
 
 class RHEL3Guest(oz.RedHat.RedHatCDGuest):
     """
@@ -44,8 +43,8 @@ class RHEL3Guest(oz.RedHat.RedHatCDGuest):
         self.auto = auto
 
         # override the sshd_config value set in RedHatCDGuest.__init__
-        self.sshd_config = \
-"""SyslogFacility AUTHPRIV
+        self.sshd_config = """\
+SyslogFacility AUTHPRIV
 PasswordAuthentication yes
 ChallengeResponseAuthentication no
 X11Forwarding yes
@@ -56,7 +55,7 @@ Subsystem	sftp	/usr/libexec/openssh/sftp-server
         """
         Method to make the boot ISO auto-boot with appropriate parameters.
         """
-        self._copy_kickstart(os.path.join(self.iso_contents, "ks.cfg"))
+        self._copy_kickstart(join(self.iso_contents, "ks.cfg"))
 
         initrdline = "  append initrd=initrd.img ks=cdrom:/ks.cfg method="
         if self.tdl.installtype == "url":
@@ -74,17 +73,17 @@ Subsystem	sftp	/usr/libexec/openssh/sftp-server
         cdfd.close()
 
         if pvd.system_identifier != "LINUX                           ":
-            raise oz.OzException.OzException("Invalid system identifier on ISO for " + self.tdl.distro + " install")
+            raise OzException("Invalid system identifier on ISO for " + self.tdl.distro + " install")
 
         if self.tdl.distro == "RHEL-3":
             if self.tdl.installtype == "iso":
-                raise oz.OzException.OzException("BUG: shouldn't be able to reach RHEL-3 with ISO checking")
+                raise OzException("BUG: shouldn't be able to reach RHEL-3 with ISO checking")
             # The boot ISOs for RHEL-3 don't have a whole lot of identifying
             # information.  We just pass through here, doing nothing
         else:
             if self.tdl.installtype == "iso":
                 if not re.match("CentOS-3(\.[0-9])? Disk 1", pvd.volume_identifier) and not re.match("CentOS-3(\.[0-9])? server", pvd.volume_identifier) and not re.match("CentOS-3(\.[0-9])? " + self.tdl.arch + " DVD", pvd.volume_identifier):
-                    raise oz.OzException.OzException("Only DVDs are supported for CentOS-3 ISO installs")
+                    raise OzException("Only DVDs are supported for CentOS-3 ISO installs")
             # The boot ISOs for CentOS-3 don't have a whole lot of identifying
             # information.  We just pass through here, doing nothing
 

--- a/oz/RHEL_4.py
+++ b/oz/RHEL_4.py
@@ -19,11 +19,10 @@ RHEL-4 installation
 """
 
 import re
-import os
+from os.path import join
 
-import oz.ozutil
 import oz.RedHat
-import oz.OzException
+from oz.OzException import OzException
 
 class RHEL4Guest(oz.RedHat.RedHatCDGuest):
     """
@@ -43,7 +42,7 @@ class RHEL4Guest(oz.RedHat.RedHatCDGuest):
         """
         Method to make the boot ISO auto-boot with appropriate parameters.
         """
-        self._copy_kickstart(os.path.join(self.iso_contents, "ks.cfg"))
+        self._copy_kickstart(join(self.iso_contents, "ks.cfg"))
 
         initrdline = "  append initrd=initrd.img ks=cdrom:/ks.cfg method="
         if self.tdl.installtype == "url":
@@ -65,7 +64,7 @@ class RHEL4Guest(oz.RedHat.RedHatCDGuest):
         # all of the below should have "LINUX" as their system_identifier,
         # so check it here
         if pvd.system_identifier != "LINUX                           ":
-            raise oz.OzException.OzException("Invalid system identifier on ISO for " + self.tdl.distro + " install")
+            raise OzException("Invalid system identifier on ISO for " + self.tdl.distro + " install")
 
         if self.tdl.distro == "RHEL-4":
             if self.tdl.installtype == 'iso':
@@ -73,19 +72,19 @@ class RHEL4Guest(oz.RedHat.RedHatCDGuest):
                 # DVDs and CDs.  To tell them apart, we assume that if the
                 # size is smaller than 1GB, this is a CD
                 if not re.match("RHEL/4(-U[0-9])?", pvd.volume_identifier) or (pvd.space_size * 2048) < 1 * 1024 * 1024 * 1024:
-                    raise oz.OzException.OzException("Only DVDs are supported for RHEL-4 ISO installs")
+                    raise OzException("Only DVDs are supported for RHEL-4 ISO installs")
             else:
                 # url installs
                 if not pvd.volume_identifier.startswith("Red Hat Enterprise Linux"):
-                    raise oz.OzException.OzException("Invalid boot.iso for RHEL-4 URL install")
+                    raise OzException("Invalid boot.iso for RHEL-4 URL install")
         elif self.tdl.distro == "CentOS-4":
             if self.tdl.installtype == 'iso':
                 if not re.match("CentOS 4(\.[0-9])?.*DVD", pvd.volume_identifier):
-                    raise oz.OzException.OzException("Only DVDs are supported for CentOS-4 ISO installs")
+                    raise OzException("Only DVDs are supported for CentOS-4 ISO installs")
             else:
                 # url installs
                 if not re.match("CentOS *", pvd.volume_identifier):
-                    raise oz.OzException.OzException("Invalid boot.iso for CentOS-4 URL install")
+                    raise OzException("Invalid boot.iso for CentOS-4 URL install")
 
 def get_class(tdl, config, auto, output_disk=None):
     """

--- a/oz/RHEL_5.py
+++ b/oz/RHEL_5.py
@@ -20,11 +20,10 @@ RHEL-5 installation
 """
 
 import re
-import os
+from os.path import join
 
-import oz.ozutil
 import oz.RedHat
-import oz.OzException
+from oz.OzException import OzException
 
 class RHEL5Guest(oz.RedHat.RedHatCDYumGuest):
     """
@@ -45,7 +44,7 @@ class RHEL5Guest(oz.RedHat.RedHatCDYumGuest):
         """
         Method to make the boot ISO auto-boot with appropriate parameters.
         """
-        self._copy_kickstart(os.path.join(self.iso_contents, "ks.cfg"))
+        self._copy_kickstart(join(self.iso_contents, "ks.cfg"))
 
         initrdline = "  append initrd=initrd.img ks=cdrom:/ks.cfg method="
         if self.tdl.installtype == "url":
@@ -67,17 +66,17 @@ class RHEL5Guest(oz.RedHat.RedHatCDYumGuest):
         # all of the below should have "LINUX" as their system_identifier,
         # so check it here
         if pvd.system_identifier != "LINUX                           ":
-            raise oz.OzException.OzException("Invalid system identifier on ISO for " + self.tdl.distro + " install")
+            raise OzException("Invalid system identifier on ISO for " + self.tdl.distro + " install")
 
         if self.tdl.distro == "RHEL-5":
             if self.tdl.installtype == 'iso':
                 if not re.match("RHEL/5(\.[0-9])? " + self.tdl.arch + " DVD",
                                 pvd.volume_identifier):
-                    raise oz.OzException.OzException("Only DVDs are supported for RHEL-5 ISO installs")
+                    raise OzException("Only DVDs are supported for RHEL-5 ISO installs")
             else:
                 # url installs
                 if not pvd.volume_identifier.startswith("Red Hat Enterprise Linux"):
-                    raise oz.OzException.OzException("Invalid boot.iso for RHEL-5 URL install")
+                    raise OzException("Invalid boot.iso for RHEL-5 URL install")
         elif self.tdl.distro == "CentOS-5":
             # CentOS-5
             if self.tdl.installtype == 'iso':
@@ -85,20 +84,20 @@ class RHEL5Guest(oz.RedHat.RedHatCDYumGuest):
                 # DVDs and CDs.  To tell them apart, we assume that if the
                 # size is smaller than 1GB, this is a CD
                 if not re.match("CentOS_5.[0-9]_Final", pvd.volume_identifier) or (pvd.space_size * 2048) < 1 * 1024 * 1024 * 1024:
-                    raise oz.OzException.OzException("Only DVDs are supported for CentOS-5 ISO installs")
+                    raise OzException("Only DVDs are supported for CentOS-5 ISO installs")
             else:
                 # url installs
                 if not re.match("CentOS *", pvd.volume_identifier):
-                    raise oz.OzException.OzException("Invalid boot.iso for CentOS-5 URL install")
+                    raise OzException("Invalid boot.iso for CentOS-5 URL install")
         elif self.tdl.distro == "SLC-5":
             # SLC-5
             if self.tdl.installtype == 'iso':
                 if not re.match("Scientific Linux CERN 5.[0-9]", pvd.volume_identifier):
-                    raise oz.OzException.OzException("Only DVDs are supported for SLC-5 ISO installs")
+                    raise OzException("Only DVDs are supported for SLC-5 ISO installs")
             else:
                 # url installs
                 if not re.match("CentOS *", pvd.volume_identifier):
-                    raise oz.OzException.OzException("Invalid boot.iso for SLC-5 URL install")
+                    raise OzException("Invalid boot.iso for SLC-5 URL install")
 
 def get_class(tdl, config, auto, output_disk=None):
     """

--- a/oz/RHEL_6.py
+++ b/oz/RHEL_6.py
@@ -18,12 +18,8 @@
 """
 RHEL-6 installation
 """
-
-import os
-
-import oz.ozutil
+from os.path import join
 import oz.RedHat
-import oz.OzException
 
 class RHEL6Guest(oz.RedHat.RedHatCDYumGuest):
     """
@@ -41,7 +37,7 @@ class RHEL6Guest(oz.RedHat.RedHatCDYumGuest):
         """
         Method to modify the ISO for autoinstallation.
         """
-        self._copy_kickstart(os.path.join(self.iso_contents, "ks.cfg"))
+        self._copy_kickstart(join(self.iso_contents, "ks.cfg"))
 
         initrdline = "  append initrd=initrd.img ks=cdrom:/ks.cfg"
         if self.tdl.installtype == "url":

--- a/oz/RHL.py
+++ b/oz/RHL.py
@@ -20,12 +20,12 @@ RHL installation
 """
 
 import re
-import os
 import shutil
+from os.path import join
 
-import oz.ozutil
 import oz.RedHat
-import oz.OzException
+from oz.ozutil import generate_full_auto_path, copy_modify_file
+from oz.OzException import OzException
 
 class RHL9Guest(oz.RedHat.RedHatCDGuest):
     """
@@ -42,7 +42,7 @@ class RHL9Guest(oz.RedHat.RedHatCDGuest):
         self.auto = auto
 
         if self.tdl.arch != "i386":
-            raise oz.OzException.OzException("Invalid arch " + self.tdl.arch + "for RHL guest")
+            raise OzException("Invalid arch " + self.tdl.arch + "for RHL guest")
 
     def _modify_iso(self):
         """
@@ -50,7 +50,7 @@ class RHL9Guest(oz.RedHat.RedHatCDGuest):
         """
         self.log.debug("Putting the kickstart in place")
 
-        outname = os.path.join(self.iso_contents, "ks.cfg")
+        outname = join(self.iso_contents, "ks.cfg")
 
         if self.auto is None:
             def _kssub(line):
@@ -67,8 +67,7 @@ class RHL9Guest(oz.RedHat.RedHatCDGuest):
                 else:
                     return line
 
-            oz.ozutil.copy_modify_file(oz.ozutil.generate_full_auto_path(self.stock_ks),
-                                       outname, _kssub)
+            copy_modify_file(generate_full_auto_path(self.stock_ks), outname, _kssub)
         else:
             shutil.copy(self.auto, outname)
 

--- a/oz/RedHat.py
+++ b/oz/RedHat.py
@@ -30,10 +30,13 @@ except ImportError:
 import gzip
 import guestfs
 import pycurl
+from os.path import join, exists, isfile
 
 import oz.Guest
 import oz.ozutil
-import oz.OzException
+from oz.ozutil import subprocess_check_output, copy_modify_file, mkdir_p, generate_full_auto_path, config_get_key
+from oz.ozutil import ssh_execute_command, scp_copy_file, http_download_file, http_get_header, write_cpio
+from oz.OzException import OzException
 
 class RedHatCDGuest(oz.Guest.CDGuest):
     """
@@ -43,11 +46,11 @@ class RedHatCDGuest(oz.Guest.CDGuest):
                  iso_allowed, url_allowed, initrdtype):
         oz.Guest.CDGuest.__init__(self, tdl, config, output_disk, nicmodel,
                                   None, None, diskbus, iso_allowed, url_allowed)
-        self.sshprivkey = os.path.join('/etc', 'oz', 'id_rsa-icicle-gen')
+        self.sshprivkey = join('/etc', 'oz', 'id_rsa-icicle-gen')
         self.crond_was_active = False
         self.sshd_was_active = False
-        self.sshd_config = \
-"""SyslogFacility AUTHPRIV
+        self.sshd_config = """\
+SyslogFacility AUTHPRIV
 PasswordAuthentication yes
 ChallengeResponseAuthentication no
 GSSAPIAuthentication yes
@@ -65,20 +68,16 @@ Subsystem	sftp	/usr/libexec/openssh/sftp-server
 
         # initrdtype is actually a tri-state:
         # None - don't try to do direct kernel/initrd boot
-        # "cpio" - Attempt to do direct kernel/initrd boot with a gzipped CPIO
-        #        archive
-        # "ext2" - Attempt to do direct kernel/initrd boot with a gzipped ext2
-        #         filesystem
+        # "cpio" - Attempt to do direct kernel/initrd boot with a gzipped CPIO archive
+        # "ext2" - Attempt to do direct kernel/initrd boot with a gzipped ext2 filesystem
         self.initrdtype = initrdtype
 
-        self.kernelfname = os.path.join(self.output_dir,
-                                        self.tdl.name + "-kernel")
-        self.initrdfname = os.path.join(self.output_dir,
-                                        self.tdl.name + "-ramdisk")
-        self.kernelcache = os.path.join(self.data_dir, "kernels",
-                                        self.tdl.distro + self.tdl.update + self.tdl.arch + "-kernel")
-        self.initrdcache = os.path.join(self.data_dir, "kernels",
-                                        self.tdl.distro + self.tdl.update + self.tdl.arch + "-ramdisk")
+        self.kernelfname = join(self.output_dir, self.tdl.name + "-kernel")
+        self.initrdfname = join(self.output_dir, self.tdl.name + "-ramdisk")
+        self.kernelcache = join(self.data_dir, "kernels",
+                                self.tdl.distro + self.tdl.update + self.tdl.arch + "-kernel")
+        self.initrdcache = join(self.data_dir, "kernels",
+                                self.tdl.distro + self.tdl.update + self.tdl.arch + "-ramdisk")
 
         self.cmdline = "method=" + self.url + " ks=file:/ks.cfg"
 
@@ -91,36 +90,34 @@ Subsystem	sftp	/usr/libexec/openssh/sftp-server
         Method to create a new ISO based on the modified CD/DVD.
         """
         self.log.debug("Generating new ISO")
-        oz.ozutil.subprocess_check_output(["genisoimage", "-r", "-T", "-J",
-                                           "-V", "Custom", "-no-emul-boot",
-                                           "-b", "isolinux/isolinux.bin",
-                                           "-c", "isolinux/boot.cat",
-                                           "-boot-load-size", "4",
-                                           "-boot-info-table", "-v", "-v",
-                                           "-o", self.output_iso,
-                                           self.iso_contents])
+        subprocess_check_output(["genisoimage", "-r", "-T", "-J",
+                                 "-V", "Custom", "-no-emul-boot",
+                                 "-b", "isolinux/isolinux.bin",
+                                 "-c", "isolinux/boot.cat",
+                                 "-boot-load-size", "4",
+                                 "-boot-info-table", "-v", "-v",
+                                 "-o", self.output_iso,
+                                 self.iso_contents])
 
     def _check_iso_tree(self):
-        kernel = os.path.join(self.iso_contents, "isolinux", "vmlinuz")
-        if not os.path.exists(kernel):
-            raise oz.OzException.OzException("Fedora/Red Hat installs can only be done using a boot.iso (netinst) or DVD image (LiveCDs are not supported)")
+        kernel = join(self.iso_contents, "isolinux", "vmlinuz")
+        if not exists(kernel):
+            raise OzException("Fedora/Red Hat installs can only be done using a boot.iso (netinst) or DVD image (LiveCDs are not supported)")
 
     def _modify_isolinux(self, initrdline):
         """
         Method to modify the isolinux.cfg file on a RedHat style CD.
         """
         self.log.debug("Modifying isolinux.cfg")
-        isolinuxcfg = os.path.join(self.iso_contents, "isolinux",
-                                   "isolinux.cfg")
+        isolinuxcfg = join(self.iso_contents, "isolinux", "isolinux.cfg")
 
-        f = open(isolinuxcfg, "w")
-        f.write("default customiso\n")
-        f.write("timeout 1\n")
-        f.write("prompt 0\n")
-        f.write("label customiso\n")
-        f.write("  kernel vmlinuz\n")
-        f.write(initrdline)
-        f.close()
+        with open(isolinuxcfg, "w") as f:
+            f.write("default customiso\n")
+            f.write("timeout 1\n")
+            f.write("prompt 0\n")
+            f.write("label customiso\n")
+            f.write("  kernel vmlinuz\n")
+            f.write(initrdline)
 
     def _copy_kickstart(self, outname):
         """
@@ -139,8 +136,7 @@ Subsystem	sftp	/usr/libexec/openssh/sftp-server
                 else:
                     return line
 
-            oz.ozutil.copy_modify_file(oz.ozutil.generate_full_auto_path(self.stock_ks),
-                                       outname, _kssub)
+            copy_modify_file(generate_full_auto_path(self.stock_ks), outname, _kssub)
         else:
             shutil.copy(self.auto, outname)
 
@@ -268,15 +264,10 @@ Subsystem	sftp	/usr/libexec/openssh/sftp-server
 
         try:
             self._image_ssh_teardown_step_1(g_handle)
-
             self._image_ssh_teardown_step_2(g_handle)
-
             self._image_ssh_teardown_step_3(g_handle)
-
             self._image_ssh_teardown_step_4(g_handle)
-
             self._image_ssh_teardown_step_5(g_handle)
-
             self._image_ssh_teardown_step_6(g_handle)
         finally:
             self._guestfs_handle_cleanup(g_handle)
@@ -304,7 +295,7 @@ Subsystem	sftp	/usr/libexec/openssh/sftp-server
         # part 2; check and setup sshd
         self.log.debug("Step 2: setup sshd")
         if not g_handle.exists('/usr/sbin/sshd'):
-            raise oz.OzException.OzException("ssh not installed on the image, cannot continue")
+            raise OzException("ssh not installed on the image, cannot continue")
 
         if g_handle.exists('/lib/systemd/system/sshd.service'):
             if g_handle.exists('/etc/systemd/system/multi-user.target.wants/sshd.service'):
@@ -317,10 +308,9 @@ Subsystem	sftp	/usr/libexec/openssh/sftp-server
             self._guestfs_path_backup(g_handle, startuplink)
             g_handle.ln_sf('/etc/init.d/sshd', startuplink)
 
-        sshd_config_file = os.path.join(self.icicle_tmp, "sshd_config")
-        f = open(sshd_config_file, 'w')
-        f.write(self.sshd_config)
-        f.close()
+        sshd_config_file = join(self.icicle_tmp, "sshd_config")
+        with open(sshd_config_file, 'w') as f:
+            f.write(self.sshd_config)
 
         try:
             self._guestfs_path_backup(g_handle, '/etc/ssh/sshd_config')
@@ -344,27 +334,29 @@ Subsystem	sftp	/usr/libexec/openssh/sftp-server
         # part 4; make sure the guest announces itself
         self.log.debug("Step 4: Guest announcement")
         if not g_handle.exists('/usr/sbin/crond'):
-            raise oz.OzException.OzException("cron not installed on the image, cannot continue")
+            raise OzException("cron not installed on the image, cannot continue")
 
-        scriptfile = os.path.join(self.icicle_tmp, "script")
-        f = open(scriptfile, 'w')
-        f.write("#!/bin/bash\n")
-        f.write("DEV=$(/bin/awk '{if ($2 == 0) print $1}' /proc/net/route) &&\n")
-        f.write('[ -z "$DEV" ] && exit 0\n')
-        f.write("ADDR=$(/sbin/ip -4 -o addr show dev $DEV | /bin/awk '{print $4}' | /bin/cut -d/ -f1) &&\n")
-        f.write('[ -z "$ADDR" ] && exit 0\n')
-        f.write('echo -n "!$ADDR,%s!" > /dev/ttyS0\n' % (self.uuid))
-        f.close()
+        scriptfile = join(self.icicle_tmp, "script")
+        with open(scriptfile, 'w') as f:
+            f.write("""\
+#!/bin/bash
+DEV=$(/bin/awk '{if ($2 == 0) print $1}' /proc/net/route) &&
+[ -z "$DEV" ] && exit 0
+ADDR=$(/sbin/ip -4 -o addr show dev $DEV | /bin/awk '{print $4}' | /bin/cut -d/ -f1) &&
+[ -z "$ADDR" ] && exit 0
+echo -n "!$ADDR,%s!" > /dev/ttyS0
+"""% (self.uuid))
+
         try:
             g_handle.upload(scriptfile, '/root/reportip')
             g_handle.chmod(0o755, '/root/reportip')
         finally:
             os.unlink(scriptfile)
 
-        announcefile = os.path.join(self.icicle_tmp, "announce")
-        f = open(announcefile, 'w')
-        f.write('*/1 * * * * root /bin/bash -c "/root/reportip"\n')
-        f.close()
+        announcefile = join(self.icicle_tmp, "announce")
+        with open(announcefile, 'w') as f:
+            f.write('*/1 * * * * root /bin/bash -c "/root/reportip"\n')
+
         try:
             g_handle.upload(announcefile, '/etc/cron.d/announce')
         finally:
@@ -391,10 +383,10 @@ Subsystem	sftp	/usr/libexec/openssh/sftp-server
         self._guestfs_path_backup(g_handle, '/etc/selinux/config')
 
         selinuxfile = self.icicle_tmp + "/selinux"
-        f = open(selinuxfile, 'w')
-        f.write("SELINUX=permissive\n")
-        f.write("SELINUXTYPE=targeted\n")
-        f.close()
+        with open(selinuxfile, 'w') as f:
+            f.write("SELINUX=permissive\n")
+            f.write("SELINUXTYPE=targeted\n")
+
         try:
             g_handle.upload(selinuxfile, "/etc/selinux/config")
         finally:
@@ -449,13 +441,11 @@ Subsystem	sftp	/usr/libexec/openssh/sftp-server
         finally:
             self._guestfs_handle_cleanup(g_handle)
 
-    def guest_execute_command(self, guestaddr, command, timeout=10,
-                              tunnels=None):
+    def guest_execute_command(self, guestaddr, command, timeout=10, tunnels=None):
         """
         Method to execute a command on the guest and return the output.
         """
-        return oz.ozutil.ssh_execute_command(guestaddr, self.sshprivkey,
-                                             command, timeout, tunnels)
+        return ssh_execute_command(guestaddr, self.sshprivkey, command, timeout, tunnels)
 
     def do_icicle(self, guestaddr):
         """
@@ -467,16 +457,13 @@ Subsystem	sftp	/usr/libexec/openssh/sftp-server
                                                              'rpm -qa',
                                                              timeout=30)
 
-        return self._output_icicle_xml(stdout.split("\n"),
-                                       self.tdl.description)
+        return self._output_icicle_xml(stdout.split("\n"), self.tdl.description)
 
-    def guest_live_upload(self, guestaddr, file_to_upload, destination,
-                          timeout=10):
+    def guest_live_upload(self, guestaddr, file_to_upload, destination, timeout=10):
         """
         Method to copy a file to the live guest.
         """
-        return oz.ozutil.scp_copy_file(guestaddr, self.sshprivkey,
-                                       file_to_upload, destination, timeout)
+        return scp_copy_file(guestaddr, self.sshprivkey, file_to_upload, destination, timeout)
 
     def _customize_files(self, guestaddr):
         """
@@ -484,10 +471,10 @@ Subsystem	sftp	/usr/libexec/openssh/sftp-server
         """
         self.log.info("Uploading custom files")
         for name, content in list(self.tdl.files.items()):
-            localname = os.path.join(self.icicle_tmp, "file")
-            f = open(localname, 'w')
-            f.write(content)
-            f.close()
+            localname = join(self.icicle_tmp, "file")
+            with open(localname, 'w') as f:
+                f.write(content)
+
             try:
                 self.guest_live_upload(guestaddr, localname, name)
             finally:
@@ -544,18 +531,18 @@ Subsystem	sftp	/usr/libexec/openssh/sftp-server
 
         # first we check if the .treeinfo exists; this throws an exception if
         # it is missing
-        info = oz.ozutil.http_get_header(treeinfourl)
+        info = http_get_header(treeinfourl)
         if info['HTTP-Code'] != 200:
-            raise oz.OzException.OzException("Could not find %s" % (treeinfourl))
+            raise OzException("Could not find %s" % (treeinfourl))
 
-        treeinfo = os.path.join(self.icicle_tmp, "treeinfo")
+        treeinfo = join(self.icicle_tmp, "treeinfo")
         self.log.debug("Going to write treeinfo to %s" % (treeinfo))
         treeinfofd = os.open(treeinfo, os.O_RDWR | os.O_CREAT | os.O_TRUNC)
         os.unlink(treeinfo)
         fp = os.fdopen(treeinfofd)
         try:
             self.log.debug("Trying to get treeinfo from " + treeinfourl)
-            oz.ozutil.http_download_file(treeinfourl, treeinfofd,
+            http_download_file(treeinfourl, treeinfofd,
                                          False, self.log)
 
             # if we made it here, the .treeinfo existed.  Parse it and
@@ -565,13 +552,13 @@ Subsystem	sftp	/usr/libexec/openssh/sftp-server
             config = configparser.SafeConfigParser()
             config.readfp(fp)
             section = "images-%s" % (self.tdl.arch)
-            kernel = oz.ozutil.config_get_key(config, section, "kernel", None)
-            initrd = oz.ozutil.config_get_key(config, section, "initrd", None)
+            kernel = config_get_key(config, section, "kernel", None)
+            initrd = config_get_key(config, section, "initrd", None)
         finally:
             fp.close()
 
         if kernel is None or initrd is None:
-            raise oz.OzException.OzException("Empty kernel or initrd")
+            raise OzException("Empty kernel or initrd")
 
         self.log.debug("Returning kernel %s and initrd %s" % (kernel, initrd))
         return (kernel, initrd)
@@ -600,11 +587,11 @@ Subsystem	sftp	/usr/libexec/openssh/sftp-server
         """
         # if initrdtype is cpio, then we can just append a gzipped
         # archive onto the end of the initrd
-        extrafname = os.path.join(self.icicle_tmp, "extra.cpio")
+        extrafname = join(self.icicle_tmp, "extra.cpio")
         self.log.debug("Writing cpio to %s" % (extrafname))
         cpiofiledict = {}
         cpiofiledict[kspath] = 'ks.cfg'
-        oz.ozutil.write_cpio(cpiofiledict, extrafname)
+        write_cpio(cpiofiledict, extrafname)
 
         try:
             shutil.copyfile(self.initrdcache, self.initrdfname)
@@ -619,10 +606,10 @@ Subsystem	sftp	/usr/libexec/openssh/sftp-server
         # in this case, the archive is not CPIO but is an ext2
         # filesystem.  use guestfs to mount it and add the kickstart
         self.log.debug("Creating temporary directory")
-        tmpdir = os.path.join(self.icicle_tmp, "initrd")
-        oz.ozutil.mkdir_p(tmpdir)
+        tmpdir = join(self.icicle_tmp, "initrd")
+        mkdir_p(tmpdir)
 
-        ext2file = os.path.join(tmpdir, "initrd.ext2")
+        ext2file = join(tmpdir, "initrd.ext2")
         self.log.debug("Uncompressing initrd %s to %s" % (self.initrdfname, ext2file))
         inf = gzip.open(self.initrdcache, 'rb')
         outf = open(ext2file, "w")
@@ -688,7 +675,7 @@ Subsystem	sftp	/usr/libexec/openssh/sftp-server
         shutil.copyfile(self.kernelcache, self.kernelfname)
 
         try:
-            kspath = os.path.join(self.icicle_tmp, self.stock_ks)
+            kspath = join(self.icicle_tmp, self.stock_ks)
             self._copy_kickstart(kspath)
 
             try:
@@ -697,7 +684,7 @@ Subsystem	sftp	/usr/libexec/openssh/sftp-server
                 elif self.initrdtype == "ext2":
                     self._create_ext2_initrd(kspath)
                 else:
-                    raise oz.OzException.OzException("Invalid initrdtype, this is a programming error")
+                    raise OzException("Invalid initrdtype, this is a programming error")
             finally:
                 os.unlink(kspath)
         except:
@@ -802,7 +789,7 @@ class RedHatCDYumGuest(RedHatCDGuest):
             # supports byte ranges, fail.
             count = 5
             while count > 0:
-                info = oz.ozutil.http_get_header(url, redirect=False)
+                info = http_get_header(url, redirect=False)
 
                 if 'Accept-Ranges' in info and info['Accept-Ranges'] == "none":
                     if url == info['Redirect-URL']:
@@ -820,7 +807,7 @@ class RedHatCDYumGuest(RedHatCDGuest):
                 break
 
             if count == 0:
-                raise oz.OzException.OzException("%s URL installs cannot be done using servers that don't accept byte ranges.  Please try another mirror" % (self.tdl.distro))
+                raise OzException("%s URL installs cannot be done using servers that don't accept byte ranges.  Please try another mirror" % (self.tdl.distro))
 
         return url
 
@@ -849,7 +836,7 @@ class RedHatCDYumGuest(RedHatCDGuest):
                 port = self._protocol_to_default_port[protocol]
             return (protocol, hostname, port, path)
         else:
-            raise oz.OzException.OzException("Could not decode URL (%s) for port forwarding" % (repourl))
+            raise OzException("Could not decode URL (%s) for port forwarding" % (repourl))
 
     def _discover_repo_locality(self, repo_url, guestaddr, certdict):
         """
@@ -904,8 +891,7 @@ class RedHatCDYumGuest(RedHatCDGuest):
 
         # now check if we can access it remotely
         try:
-            self.guest_execute_command(guestaddr,
-                                       "curl --silent %s %s" % (curlargs, full_url))
+            self.guest_execute_command(guestaddr, "curl --silent %s %s" % (curlargs, full_url))
             # if we reach here, then the perform succeeded, which means we
             # could reach the repo from the guest
             guest = True
@@ -979,13 +965,13 @@ class RedHatCDYumGuest(RedHatCDGuest):
             def _create_certfiles(repo, cert, fileext, propname):
                 certdict[propname] = {}
                 filename = "%s-%s" % (repo.name.replace(" ", "_"), fileext)
-                localname = os.path.join(self.icicle_tmp, filename)
+                localname = join(self.icicle_tmp, filename)
                 certdict[propname]["localname"] = localname
-                f = open(localname, 'w')
-                f.write(cert)
-                f.close()
+                with open(localname, 'w') as f:
+                    f.write(cert)
+
                 try:
-                    remotename = os.path.join(self._remotecertdir, filename)
+                    remotename = join(self._remotecertdir, filename)
                     if not self._remotecertdir_created:
                         self.guest_execute_command(guestaddr,
                                                    "mkdir -p %s" % (self._remotecertdir))
@@ -1021,16 +1007,16 @@ class RedHatCDYumGuest(RedHatCDGuest):
             finally:
                 # Clean up any local copies of the cert files
                 for cert in certdict:
-                    if os.path.isfile(certdict[cert]["localname"]):
+                    if isfile(certdict[cert]["localname"]):
                         os.unlink(certdict[cert]["localname"])
                 # FIXME: Clean these up on the remote end of things if we fail
                 # anywhere below
 
             if not host and not guest:
-                raise oz.OzException.OzException("Could not reach repository %s from the host or the guest, aborting" % (repo.url))
+                raise OzException("Could not reach repository %s from the host or the guest, aborting" % (repo.url))
 
             filename = repo.name.replace(" ", "_") + ".repo"
-            localname = os.path.join(self.icicle_tmp, filename)
+            localname = join(self.icicle_tmp, filename)
             f = open(localname, 'w')
             f.write("[%s]\n" % repo.name.replace(" ", "_"))
             f.write("name=%s\n" % repo.name)
@@ -1076,7 +1062,7 @@ class RedHatCDYumGuest(RedHatCDGuest):
             f.close()
 
             try:
-                remotename = os.path.join("/etc/yum.repos.d/", filename)
+                remotename = join("/etc/yum.repos.d/", filename)
                 self.guest_live_upload(guestaddr, localname, remotename)
                 repo.remotefiles.append(remotename)
             finally:
@@ -1137,7 +1123,7 @@ class RedHatCDYumGuest(RedHatCDGuest):
                 count -= 1
 
         if not success:
-            raise oz.OzException.OzException("Failed to connect to ssh on running guest")
+            raise OzException("Failed to connect to ssh on running guest")
 
     def _internal_customize(self, libvirt_xml, action):
         """
@@ -1183,7 +1169,7 @@ class RedHatCDYumGuest(RedHatCDGuest):
                 elif action == "mod_only":
                     self.do_customize(guestaddr)
                 else:
-                    raise oz.OzException.OzException("Invalid customize action %s; this is a programming error" % (action))
+                    raise OzException("Invalid customize action %s; this is a programming error" % (action))
             finally:
                 self._shutdown_guest(guestaddr, libvirt_dom)
         finally:
@@ -1222,25 +1208,25 @@ class RedHatFDGuest(oz.Guest.FDGuest):
                                   None, None, None)
 
         if self.tdl.arch != "i386":
-            raise oz.OzException.OzException("Invalid arch " + self.tdl.arch + "for " + self.tdl.distro + " guest")
+            raise OzException("Invalid arch " + self.tdl.arch + "for " + self.tdl.distro + " guest")
 
         self.ks_name = ks_name
 
         self.ks_file = auto
         if self.ks_file is None:
-            self.ks_file = oz.ozutil.generate_full_auto_path(self.ks_name)
+            self.ks_file = generate_full_auto_path(self.ks_name)
 
     def _modify_floppy(self):
         """
         Method to make the floppy auto-boot with appropriate parameters.
         """
-        oz.ozutil.mkdir_p(self.floppy_contents)
+        mkdir_p(self.floppy_contents)
 
         self.log.debug("Putting the kickstart in place")
 
-        output_ks = os.path.join(self.floppy_contents, "ks.cfg")
+        output_ks = join(self.floppy_contents, "ks.cfg")
 
-        if self.ks_file == oz.ozutil.generate_full_auto_path(self.ks_name):
+        if self.ks_file == generate_full_auto_path(self.ks_name):
             def _kssub(line):
                 """
                 Method that is called back from oz.ozutil.copy_modify_file() to
@@ -1253,16 +1239,15 @@ class RedHatFDGuest(oz.Guest.FDGuest):
                 else:
                     return line
 
-            oz.ozutil.copy_modify_file(self.ks_file, output_ks, _kssub)
+            copy_modify_file(self.ks_file, output_ks, _kssub)
         else:
             shutil.copy(self.ks_file, output_ks)
 
-        oz.ozutil.subprocess_check_output(["mcopy", "-i", self.output_floppy,
-                                           output_ks, "::KS.CFG"])
+        subprocess_check_output(["mcopy", "-i", self.output_floppy, output_ks, "::KS.CFG"])
 
         self.log.debug("Modifying the syslinux.cfg")
 
-        syslinux = os.path.join(self.floppy_contents, "SYSLINUX.CFG")
+        syslinux = join(self.floppy_contents, "SYSLINUX.CFG")
         outfile = open(syslinux, "w")
         outfile.write("default customboot\n")
         outfile.write("prompt 1\n")
@@ -1274,13 +1259,13 @@ class RedHatFDGuest(oz.Guest.FDGuest):
 
         # sometimes, syslinux.cfg on the floppy gets marked read-only.  Avoid
         # problems with the subsequent mcopy by marking it read/write.
-        oz.ozutil.subprocess_check_output(["mattrib", "-r", "-i",
-                                           self.output_floppy,
-                                           "::SYSLINUX.CFG"])
+        subprocess_check_output(["mattrib", "-r", "-i",
+                                 self.output_floppy,
+                                 "::SYSLINUX.CFG"])
 
-        oz.ozutil.subprocess_check_output(["mcopy", "-n", "-o", "-i",
-                                           self.output_floppy, syslinux,
-                                           "::SYSLINUX.CFG"])
+        subprocess_check_output(["mcopy", "-n", "-o", "-i",
+                                 self.output_floppy, syslinux,
+                                 "::SYSLINUX.CFG"])
 
     def generate_install_media(self, force_download=False):
         """

--- a/oz/Ubuntu.py
+++ b/oz/Ubuntu.py
@@ -24,10 +24,12 @@ import re
 import os
 import libvirt
 import gzip
+from os.path import join, isdir, dirname
 
 import oz.Guest
-import oz.ozutil
-import oz.OzException
+from oz.ozutil import generate_full_auto_path, copy_modify_file, subprocess_check_output, mkdir_p
+from oz.ozutil import ssh_execute_command, scp_copy_file, http_download_file, http_get_header, write_cpio
+from oz.OzException import OzException
 
 class UbuntuGuest(oz.Guest.CDGuest):
     """
@@ -47,11 +49,11 @@ class UbuntuGuest(oz.Guest.CDGuest):
         oz.Guest.CDGuest.__init__(self, tdl, config, output_disk, nicmodel,
                                   None, None, diskbus, True, True)
 
-        self.sshprivkey = os.path.join('/etc', 'oz', 'id_rsa-icicle-gen')
+        self.sshprivkey = join('/etc', 'oz', 'id_rsa-icicle-gen')
         self.crond_was_active = False
         self.sshd_was_active = False
-        self.sshd_config = \
-"""SyslogFacility AUTHPRIV
+        self.sshd_config = """\
+SyslogFacility AUTHPRIV
 PasswordAuthentication yes
 ChallengeResponseAuthentication no
 GSSAPIAuthentication yes
@@ -69,7 +71,7 @@ Subsystem       sftp    /usr/libexec/openssh/sftp-server
 
         self.preseed_file = auto
         if self.preseed_file is None:
-            self.preseed_file = oz.ozutil.generate_full_auto_path("ubuntu-" + self.tdl.update + "-jeos.preseed")
+            self.preseed_file = generate_full_auto_path("ubuntu-" + self.tdl.update + "-jeos.preseed")
         self.tunnels = {}
 
         self.ssh_startuplink = None
@@ -79,21 +81,19 @@ Subsystem       sftp    /usr/libexec/openssh/sftp-server
         if self.debarch == "x86_64":
             self.debarch = "amd64"
 
-        self.kernelfname = os.path.join(self.output_dir,
-                                        self.tdl.name + "-kernel")
-        self.initrdfname = os.path.join(self.output_dir,
-                                        self.tdl.name + "-ramdisk")
-        self.kernelcache = os.path.join(self.data_dir, "kernels",
-                                        self.tdl.distro + self.tdl.update + self.tdl.arch + "-kernel")
-        self.initrdcache = os.path.join(self.data_dir, "kernels",
-                                        self.tdl.distro + self.tdl.update + self.tdl.arch + "-ramdisk")
+        self.kernelfname = join(self.output_dir, self.tdl.name + "-kernel")
+        self.initrdfname = join(self.output_dir, self.tdl.name + "-ramdisk")
+        self.kernelcache = join(self.data_dir, "kernels",
+                                self.tdl.distro + self.tdl.update + self.tdl.arch + "-kernel")
+        self.initrdcache = join(self.data_dir, "kernels",
+                                self.tdl.distro + self.tdl.update + self.tdl.arch + "-ramdisk")
 
         self.cmdline = "priority=critical locale=en_US"
 
     def _check_iso_tree(self):
         if self.tdl.update in ["6.06", "6.10", "7.04"]:
-            if os.path.isdir(os.path.join(self.iso_contents, "casper")):
-                raise oz.OzException.OzException("Ubuntu %s installs can only be done using the alternate or server CDs" % (self.tdl.update))
+            if isdir(join(self.iso_contents, "casper")):
+                raise OzException("Ubuntu %s installs can only be done using the alternate or server CDs" % (self.tdl.update))
 
     def _copy_preseed(self, outname):
         """
@@ -101,7 +101,7 @@ Subsystem       sftp    /usr/libexec/openssh/sftp-server
         """
         self.log.debug("Putting the preseed file in place")
 
-        if self.preseed_file == oz.ozutil.generate_full_auto_path("ubuntu-" + self.tdl.update + "-jeos.preseed"):
+        if self.preseed_file == generate_full_auto_path("ubuntu-" + self.tdl.update + "-jeos.preseed"):
 
             def _preseed_sub(line):
                 """
@@ -115,7 +115,7 @@ Subsystem       sftp    /usr/libexec/openssh/sftp-server
                 else:
                     return line
 
-            oz.ozutil.copy_modify_file(self.preseed_file, outname, _preseed_sub)
+            copy_modify_file(self.preseed_file, outname, _preseed_sub)
         else:
             shutil.copy(self.preseed_file, outname)
 
@@ -126,22 +126,21 @@ Subsystem       sftp    /usr/libexec/openssh/sftp-server
         self.log.debug("Modifying ISO")
 
         self.log.debug("Copying preseed file")
-        outname = os.path.join(self.iso_contents, "preseed", "customiso.seed")
-        outdir = os.path.dirname(outname)
-        oz.ozutil.mkdir_p(outdir)
+        outname = join(self.iso_contents, "preseed", "customiso.seed")
+        outdir = dirname(outname)
+        mkdir_p(outdir)
 
         self._copy_preseed(outname)
 
         self.log.debug("Modifying isolinux.cfg")
-        isolinuxcfg = os.path.join(self.iso_contents, "isolinux",
-                                   "isolinux.cfg")
-        isolinuxdir = os.path.dirname(isolinuxcfg)
-        if not os.path.isdir(isolinuxdir):
-            oz.ozutil.mkdir_p(isolinuxdir)
-            shutil.copyfile(os.path.join(self.iso_contents, "isolinux.bin"),
-                            os.path.join(isolinuxdir, "isolinux.bin"))
-            shutil.copyfile(os.path.join(self.iso_contents, "boot.cat"),
-                            os.path.join(isolinuxdir, "boot.cat"))
+        isolinuxcfg = join(self.iso_contents, "isolinux", "isolinux.cfg")
+        isolinuxdir = dirname(isolinuxcfg)
+        if not isdir(isolinuxdir):
+            mkdir_p(isolinuxdir)
+            shutil.copyfile(join(self.iso_contents, "isolinux.bin"),
+                            join(isolinuxdir, "isolinux.bin"))
+            shutil.copyfile(join(self.iso_contents, "boot.cat"),
+                            join(isolinuxdir, "boot.cat"))
         f = open(isolinuxcfg, 'w')
         f.write("default customiso\n")
         f.write("timeout 1\n")
@@ -149,7 +148,7 @@ Subsystem       sftp    /usr/libexec/openssh/sftp-server
         f.write("label customiso\n")
         f.write("  menu label ^Customiso\n")
         f.write("  menu default\n")
-        if os.path.isdir(os.path.join(self.iso_contents, "casper")):
+        if isdir(join(self.iso_contents, "casper")):
             f.write("  kernel /casper/vmlinuz\n")
             f.write("  append file=/cdrom/preseed/customiso.seed boot=casper automatic-ubiquity noprompt keyboard-configuration/layoutcode=us initrd=/casper/" + self.casper_initrd + "\n")
         else:
@@ -165,14 +164,14 @@ Subsystem       sftp    /usr/libexec/openssh/sftp-server
         Method to create a new ISO based on the modified CD/DVD.
         """
         self.log.info("Generating new ISO")
-        oz.ozutil.subprocess_check_output(["genisoimage", "-r", "-V", "Custom",
-                                           "-J", "-l", "-no-emul-boot",
-                                           "-b", "isolinux/isolinux.bin",
-                                           "-c", "isolinux/boot.cat",
-                                           "-boot-load-size", "4",
-                                           "-cache-inodes", "-boot-info-table",
-                                           "-v", "-v", "-o", self.output_iso,
-                                           self.iso_contents])
+        subprocess_check_output(["genisoimage", "-r", "-V", "Custom",
+                                 "-J", "-l", "-no-emul-boot",
+                                 "-b", "isolinux/isolinux.bin",
+                                 "-c", "isolinux/boot.cat",
+                                 "-boot-load-size", "4",
+                                 "-cache-inodes", "-boot-info-table",
+                                 "-v", "-v", "-o", self.output_iso,
+                                 self.iso_contents])
 
     def install(self, timeout=None, force=False):
         """
@@ -295,16 +294,15 @@ Subsystem       sftp    /usr/libexec/openssh/sftp-server
         # part 2; check and setup sshd
         self.log.debug("Step 2: setup sshd")
         if not g_handle.exists('/usr/sbin/sshd'):
-            raise oz.OzException.OzException("ssh not installed on the image, cannot continue")
+            raise OzException("ssh not installed on the image, cannot continue")
 
         self.ssh_startuplink = self._get_service_runlevel_link(g_handle, 'ssh')
         self._guestfs_path_backup(g_handle, self.ssh_startuplink)
         g_handle.ln_sf('/etc/init.d/ssh', self.ssh_startuplink)
 
-        sshd_config_file = os.path.join(self.icicle_tmp, "sshd_config")
-        f = open(sshd_config_file, 'w')
-        f.write(self.sshd_config)
-        f.close()
+        sshd_config_file = join(self.icicle_tmp, "sshd_config")
+        with open(sshd_config_file, 'w') as f:
+            f.write(self.sshd_config)
 
         try:
             self._guestfs_path_backup(g_handle, '/etc/ssh/sshd_config')
@@ -320,35 +318,36 @@ Subsystem       sftp    /usr/libexec/openssh/sftp-server
         # part 3; make sure the guest announces itself
         self.log.debug("Step 3: Guest announcement")
         if not g_handle.exists('/usr/sbin/cron'):
-            raise oz.OzException.OzException("cron not installed on the image, cannot continue")
+            raise OzException("cron not installed on the image, cannot continue")
 
-        scriptfile = os.path.join(self.icicle_tmp, "script")
-        f = open(scriptfile, 'w')
-        f.write("#!/bin/bash\n")
-        f.write("/bin/sleep 20\n")
-        f.write("DEV=$(/usr/bin/awk '{if ($2 == 0) print $1}' /proc/net/route) &&\n")
-        f.write('[ -z "$DEV" ] && exit 0\n')
-        f.write("ADDR=$(/sbin/ip -4 -o addr show dev $DEV | /usr/bin/awk '{print $4}' | /usr/bin/cut -d/ -f1) &&\n")
-        f.write('[ -z "$ADDR" ] && exit 0\n')
-        f.write('echo -n "!$ADDR,%s!" > /dev/ttyS0\n' % (self.uuid))
-        f.close()
+        scriptfile = join(self.icicle_tmp, "script")
+        with open(scriptfile, 'w') as f:
+            f.write("""\
+#!/bin/bash
+/bin/sleep 20
+DEV=$(/usr/bin/awk '{if ($2 == 0) print $1}' /proc/net/route) &&\
+[ -z "$DEV" ] && exit 0
+ADDR=$(/sbin/ip -4 -o addr show dev $DEV | /usr/bin/awk '{print $4}' | /usr/bin/cut -d/ -f1) &&
+[ -z "$ADDR" ] && exit 0
+echo -n "!$ADDR,%s!" > /dev/ttyS0
+""" % (self.uuid))
+
         try:
             g_handle.upload(scriptfile, '/root/reportip')
             g_handle.chmod(0o755, '/root/reportip')
         finally:
             os.unlink(scriptfile)
 
-        announcefile = os.path.join(self.icicle_tmp, "announce")
-        f = open(announcefile, 'w')
-        f.write('*/1 * * * * root /bin/bash -c "/root/reportip"\n')
-        f.close()
+        announcefile = join(self.icicle_tmp, "announce")
+        with open(announcefile, 'w') as f:
+            f.write('*/1 * * * * root /bin/bash -c "/root/reportip"\n')
+
         try:
             g_handle.upload(announcefile, '/etc/cron.d/announce')
         finally:
             os.unlink(announcefile)
 
-        self.cron_startuplink = self._get_service_runlevel_link(g_handle,
-                                                                'cron')
+        self.cron_startuplink = self._get_service_runlevel_link(g_handle, 'cron')
         self._guestfs_path_backup(g_handle, self.cron_startuplink)
         g_handle.ln_sf('/etc/init.d/cron', self.cron_startuplink)
 
@@ -398,11 +397,8 @@ Subsystem       sftp    /usr/libexec/openssh/sftp-server
 
         try:
             self._image_ssh_teardown_step_1(g_handle)
-
             self._image_ssh_teardown_step_2(g_handle)
-
             self._image_ssh_teardown_step_3(g_handle)
-
             self._image_ssh_teardown_step_4(g_handle)
         finally:
             self._guestfs_handle_cleanup(g_handle)
@@ -429,7 +425,7 @@ Subsystem       sftp    /usr/libexec/openssh/sftp-server
                 count -= 1
 
         if not success:
-            raise oz.OzException.OzException("Failed to connect to ssh on running guest")
+            raise OzException("Failed to connect to ssh on running guest")
 
     def _internal_customize(self, libvirt_xml, action):
         """
@@ -474,7 +470,7 @@ Subsystem       sftp    /usr/libexec/openssh/sftp-server
                 elif action == "mod_only":
                     self.do_customize(guestaddr)
                 else:
-                    raise oz.OzException.OzException("Invalid customize action %s; this is a programming error" % (action))
+                    raise OzException("Invalid customize action %s; this is a programming error" % (action))
             finally:
                 self._shutdown_guest(guestaddr, libvirt_dom)
         finally:
@@ -516,9 +512,7 @@ Subsystem       sftp    /usr/libexec/openssh/sftp-server
             packstr += package.name + ' '
 
         if packstr != '':
-            self.guest_execute_command(guestaddr,
-                                       'apt-get install -y %s' % (packstr),
-                                       tunnels=None)
+            self.guest_execute_command(guestaddr, 'apt-get install -y %s' % (packstr),)
 
         self._customize_files(guestaddr)
 
@@ -526,13 +520,11 @@ Subsystem       sftp    /usr/libexec/openssh/sftp-server
         for cmd in self.tdl.commands:
             self.guest_execute_command(guestaddr, cmd)
 
-    def guest_execute_command(self, guestaddr, command, timeout=10,
-                              tunnels=None):
+    def guest_execute_command(self, guestaddr, command, timeout=10, tunnels=None):
         """
         Method to execute a command on the guest and return the output.
         """
-        return oz.ozutil.ssh_execute_command(guestaddr, self.sshprivkey,
-                                             command, timeout, tunnels)
+        return ssh_execute_command(guestaddr, self.sshprivkey, command, timeout, tunnels)
 
     def do_icicle(self, guestaddr):
         """
@@ -556,13 +548,11 @@ Subsystem       sftp    /usr/libexec/openssh/sftp-server
 
         return self._output_icicle_xml(packages, self.tdl.description)
 
-    def guest_live_upload(self, guestaddr, file_to_upload, destination,
-                          timeout=10):
+    def guest_live_upload(self, guestaddr, file_to_upload, destination, timeout=10):
         """
         Method to copy a file to the live guest.
         """
-        return oz.ozutil.scp_copy_file(guestaddr, self.sshprivkey,
-                                       file_to_upload, destination, timeout)
+        return scp_copy_file(guestaddr, self.sshprivkey, file_to_upload, destination, timeout)
 
     def _customize_files(self, guestaddr):
         """
@@ -570,10 +560,10 @@ Subsystem       sftp    /usr/libexec/openssh/sftp-server
         """
         self.log.info("Uploading custom files")
         for name, content in list(self.tdl.files.items()):
-            localname = os.path.join(self.icicle_tmp, "file")
-            f = open(localname, 'w')
-            f.write(content)
-            f.close()
+            localname = join(self.icicle_tmp, "file")
+            with open(localname, 'w') as f:
+                f.write(content)
+
             try:
                 self.guest_live_upload(guestaddr, localname, name)
             finally:
@@ -616,18 +606,18 @@ Subsystem       sftp    /usr/libexec/openssh/sftp-server
 
         # first we check if the txt.cfg exists; this throws an exception if
         # it is missing
-        info = oz.ozutil.http_get_header(txtcfgurl)
+        info = http_get_header(txtcfgurl)
         if info['HTTP-Code'] != 200:
-            raise oz.OzException.OzException("Could not find %s" % (txtcfgurl))
+            raise OzException("Could not find %s" % (txtcfgurl))
 
-        txtcfg = os.path.join(self.icicle_tmp, "txt.cfg")
+        txtcfg = join(self.icicle_tmp, "txt.cfg")
         self.log.debug("Going to write txt.cfg to %s" % (txtcfg))
         txtcfgfd = os.open(txtcfg, os.O_RDWR | os.O_CREAT | os.O_TRUNC)
         os.unlink(txtcfg)
         fp = os.fdopen(txtcfgfd)
         try:
             self.log.debug("Trying to get txt.cfg from " + txtcfgurl)
-            oz.ozutil.http_download_file(txtcfgurl, txtcfgfd, False, self.log)
+            http_download_file(txtcfgurl, txtcfgfd, False, self.log)
 
             # if we made it here, the txt.cfg existed.  Parse it and
             # find out the location of the kernel and ramdisk
@@ -646,7 +636,7 @@ Subsystem       sftp    /usr/libexec/openssh/sftp-server
             fp.close()
 
         if kernel is None or initrd is None:
-            raise oz.OzException.OzException("Empty kernel or initrd")
+            raise OzException("Empty kernel or initrd")
 
         self.log.debug("Returning kernel %s and initrd %s" % (kernel, initrd))
         return (kernel, initrd)
@@ -673,11 +663,11 @@ Subsystem       sftp    /usr/libexec/openssh/sftp-server
         """
         Internal method to create a modified CPIO initrd
         """
-        extrafname = os.path.join(self.icicle_tmp, "extra.cpio")
+        extrafname = join(self.icicle_tmp, "extra.cpio")
         self.log.debug("Writing cpio to %s" % (extrafname))
         cpiofiledict = {}
         cpiofiledict[preseedpath] = 'preseed.cfg'
-        oz.ozutil.write_cpio(cpiofiledict, extrafname)
+        write_cpio(cpiofiledict, extrafname)
 
         try:
             shutil.copyfile(self.initrdcache, self.initrdfname)
@@ -725,7 +715,7 @@ Subsystem       sftp    /usr/libexec/openssh/sftp-server
         shutil.copyfile(self.kernelcache, self.kernelfname)
 
         try:
-            preseedpath = os.path.join(self.icicle_tmp, "preseed.cfg")
+            preseedpath = join(self.icicle_tmp, "preseed.cfg")
             self._copy_preseed(preseedpath)
 
             try:

--- a/oz/ozutil.py
+++ b/oz/ozutil.py
@@ -32,6 +32,7 @@ try:
 except ImportError:
     import ConfigParser as configparser
 import collections
+from os.path import dirname, abspath, join, exists, split, isdir, expanduser
 
 def generate_full_auto_path(relative):
     """
@@ -42,8 +43,7 @@ def generate_full_auto_path(relative):
     if relative is None:
         raise Exception("The relative path cannot be None")
 
-    pkg_path = os.path.dirname(__file__)
-    return os.path.abspath(os.path.join(pkg_path, "auto", relative))
+    return abspath(join(dirname(__file__), "auto", relative))
 
 def executable_exists(program):
     """
@@ -55,18 +55,18 @@ def executable_exists(program):
         """
         Helper method to check if a file exists and is executable
         """
-        return os.path.exists(fpath) and os.access(fpath, os.X_OK)
+        return exists(fpath) and os.access(fpath, os.X_OK)
 
     if program is None:
         raise Exception("Invalid program name passed")
 
-    fpath, fname = os.path.split(program)
+    fpath, fname = split(program)
     if fpath:
         if is_exe(program):
             return program
     else:
         for path in os.environ["PATH"].split(os.pathsep):
-            exe_file = os.path.join(path, program)
+            exe_file = join(path, program)
             if is_exe(exe_file):
                 return exe_file
 
@@ -406,7 +406,7 @@ def mkdir_p(path):
     try:
         os.makedirs(path)
     except OSError as err:
-        if err.errno != errno.EEXIST or not os.path.isdir(path):
+        if err.errno != errno.EEXIST or not isdir(path):
             raise
 
 def copy_modify_file(inname, outname, subfunc):
@@ -575,7 +575,7 @@ def rmtree_and_sync(directory):
     # until those updates have made it to disk.  Note that this cannot save us
     # if the system is extremely busy for other reasons, but at least the
     # problem won't be self-inflicted.
-    fd = os.open(os.path.dirname(directory), os.O_RDONLY)
+    fd = os.open(dirname(directory), os.O_RDONLY)
     os.fsync(fd)
     os.close(fd)
 
@@ -588,7 +588,7 @@ def parse_config(config_file):
     # if config_file was not None on input, then it was provided by the caller
     # and we use that instead
 
-    config_file = os.path.expanduser(config_file)
+    config_file = expanduser(config_file)
 
     config = configparser.SafeConfigParser()
     if os.access(config_file, os.F_OK):
@@ -602,7 +602,7 @@ def default_output_dir():
     else:
         directory = "~/.oz/images"
 
-    return os.path.expanduser(directory)
+    return expanduser(directory)
 
 def default_data_dir():
     if os.geteuid() == 0:
@@ -610,10 +610,10 @@ def default_data_dir():
     else:
         directory = "~/.oz"
 
-    return os.path.expanduser(directory)
+    return expanduser(directory)
 
 def default_screenshot_dir():
-    return os.path.join(default_data_dir(), "screenshots")
+    return join(default_data_dir(), "screenshots")
 
 def http_get_header(url, redirect=True):
     """


### PR DESCRIPTION
- Import OzException directly instead of referencing the full package name
- Import various os.path and oz.ozutil functions to more readable and shorter lines
- Replace multiple write() calls with a single multi line write() call

A general cleanup to utilise Pythons import abilities. This compacts the code in various places and makes it slightly more readable and lines shorter, where possible.

Also a few cases of replacing multiple write() calls with a single call that uses the multiline variable. Makes larger blocks more readable and was already being used for SSH configuration.
