### PR TITLE
Add file exists check to copyfile_sparse

### DIFF
--- a/oz/ozutil.py
+++ b/oz/ozutil.py
@@ -82,7 +82,10 @@ def copyfile_sparse(src, dest):
     if dest is None:
         raise Exception("Destination of copy cannot be None")
 
-    if os.path.samefile(src, dest):
+    if not os.path.exists(src):
+        raise Exception("Source '%s' does not exist" % (src))
+
+    if os.path.exists(dest) and os.path.samefile(src, dest):
         raise Exception("Source '%s' and dest '%s' are the same file" % (src, dest))
 
     base = os.path.basename(dest)

--- a/tests/ozutil/test_ozutil.py
+++ b/tests/ozutil/test_ozutil.py
@@ -148,6 +148,21 @@ def test_copy_sparse_zero_blocks(tmpdir):
     dstname = os.path.join(str(tmpdir), 'dst')
     oz.ozutil.copyfile_sparse(srcname, dstname)
 
+def test_copy_sparse_src_not_exists(tmpdir):
+
+    srcname = os.path.join(str(tmpdir), 'src')
+    dstname = os.path.join(str(tmpdir), 'dst')
+    open(dstname, 'w').write('dst')
+    with py.test.raises(Exception):
+        oz.ozutil.copyfile_sparse(srcname, dstname)
+
+def test_copy_sparse_dest_not_exists(tmpdir):
+    srcname = os.path.join(str(tmpdir), 'src')
+    open(srcname, 'w').write('src')
+    dstname = os.path.join(str(tmpdir), 'dst')
+    oz.ozutil.copyfile_sparse(srcname, dstname)
+
+
 # test oz.ozutil.string_to_bool
 def test_stb_no():
     for nletter in ['n', 'N']:


### PR DESCRIPTION
In acbb467709ce43b9c16b0ad2f5e025533fe8505c a os.path.samefile was added but no checks on if dest / src exist prior to it.
This is problematic especially when the destination file does not exist already. Now it only runs samefile when a dest already exists.

This makes the ozutil tests for copyfile_sparse pass again and adds 2 new ones.
