### PR TITLE
Warn instead of failing when given libvirt_xml with more than one disk

### DIFF
--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -925,7 +925,7 @@ class Guest(object):
         input_name = namenode[0].getContent()
         disks = input_doc.xpathEval('/domain/devices/disk')
         if len(disks) != 1:
-            raise oz.OzException.OzException("oz cannot handle a libvirt domain with more than 1 disk")
+            self.log.warning("oz given libvirt domain with more than 1 disk - using the first one parsed - YMMV")
         source = disks[0].xpathEval('source')
         if len(source) != 1:
             raise oz.OzException.OzException("invalid <disk> entry without a source")


### PR DESCRIPTION
Oz itself never generates libvirt XML with more than one disk.

Allowing users to pass in modified guests at their own risk allows
for some interesting use cases.

The one I'm specifically interested in involves using Image Factory
plus Oz to drive the creation of Live CD images entirely inside of
VMs.
