### PR TITLE
Bug/jeos image type

### DIFF
--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -1558,7 +1558,7 @@ class CDGuest(Guest):
         Internal method to actually run the installation.
         """
         if not force and os.access(self.jeos_filename, os.F_OK):
-            self.log.info("Found cached JEOS, using it")
+            self.log.info("Found cached JEOS (%s), using it" % (self.jeos_filename))
             oz.ozutil.copyfile_sparse(self.jeos_filename, self.diskimage)
             return self._generate_xml("hd", None)
 


### PR DESCRIPTION
Without this, changing the image_type with cached JEOS images present will cause
breakage.  We will pull in a cached JEOS even if it is of the wrong type.  This
does not end well.
