### PR TITLE
Let <command> and <files> reference external URLs

### DIFF
--- a/docs/tdl.rng
+++ b/docs/tdl.rng
@@ -93,6 +93,7 @@
                 <choice>
                   <ref name='rawtype'/>
                   <ref name='base64_or_emptytype'/>
+                  <ref name='urltype'/>
                 </choice>
               </element>
             </zeroOrMore>
@@ -113,6 +114,7 @@
                 <choice>
                   <ref name='rawtype'/>
                   <ref name='base64type'/>
+                  <ref name='urltype'/>
                 </choice>
               </element>
             </zeroOrMore>
@@ -230,7 +232,7 @@
   <define name='rawtype'>
     <optional>
       <attribute name='type'>
-	<value>raw</value>
+	    <value>raw</value>
       </attribute>
     </optional>
     <text/>
@@ -261,6 +263,13 @@
       <value>base64</value>
     </attribute>
     <ref name='base64'/>
+  </define>
+
+  <define name='urltype'>
+    <attribute name='type'>
+      <value>url</value>
+    </attribute>
+    <text/>
   </define>
 
   <define name='number'>

--- a/tests/tdl/hello.cmd
+++ b/tests/tdl/hello.cmd
@@ -1,0 +1,1 @@
+echo "hello from file://url" > /tmp/foo

--- a/tests/tdl/test-52-command-file-url.tdl
+++ b/tests/tdl/test-52-command-file-url.tdl
@@ -1,0 +1,15 @@
+<template>
+  <name>f12jeos</name>
+  <os>
+    <name>Fedora</name>
+    <version>12</version>
+    <arch>i386</arch>
+    <install type='url'>
+      <url>http://download.fedoraproject.org/pub/fedora/linux/releases/12/Fedora/x86_64/os/</url>
+    </install>
+  </os>
+  <description>My Fedora 12 JEOS image</description>
+  <commands>
+    <command name='cmd1' type='url'>file://./tests/tdl/hello.cmd</command>
+  </commands>
+</template>

--- a/tests/tdl/test-53-command-http-url.tdl
+++ b/tests/tdl/test-53-command-http-url.tdl
@@ -1,0 +1,15 @@
+<template>
+  <name>f12jeos</name>
+  <os>
+    <name>Fedora</name>
+    <version>12</version>
+    <arch>i386</arch>
+    <install type='url'>
+      <url>http://download.fedoraproject.org/pub/fedora/linux/releases/12/Fedora/x86_64/os/</url>
+    </install>
+  </os>
+  <description>My Fedora 12 JEOS image</description>
+  <commands>
+    <command name='cmd1' type='url'>https://raw.github.com/lexinator/oz/master/tests/tdl/hello.cmd</command>
+  </commands>
+</template>

--- a/tests/tdl/test-54-files-file-url.tdl
+++ b/tests/tdl/test-54-files-file-url.tdl
@@ -1,0 +1,14 @@
+<template>
+  <name>f12jeos</name>
+  <os>
+    <name>Fedora</name>
+    <version>12</version>
+    <arch>x86_64</arch>
+    <install type='url'>
+      <url>http://download.fedoraproject.org/pub/fedora/linux/releases/12/Fedora/x86_64/os/</url>
+    </install>
+  </os>
+  <files>
+    <file name='/tmp/foo' type='url'>file://tests/tdl/hello.cmd</file>
+  </files>
+</template>

--- a/tests/tdl/test-55-files-http-url.tdl
+++ b/tests/tdl/test-55-files-http-url.tdl
@@ -1,0 +1,14 @@
+<template>
+  <name>f12jeos</name>
+  <os>
+    <name>Fedora</name>
+    <version>12</version>
+    <arch>x86_64</arch>
+    <install type='url'>
+      <url>http://download.fedoraproject.org/pub/fedora/linux/releases/12/Fedora/x86_64/os/</url>
+    </install>
+  </os>
+  <files>
+    <file name='/tmp/foo' type='url'>https://raw.github.com/lexinator/oz/master/tests/tdl/hello.cmd</file>
+  </files>
+</template>

--- a/tests/tdl/test_tdl.py
+++ b/tests/tdl/test_tdl.py
@@ -86,6 +86,10 @@ tests = {
     "test-49-file-empty-raw.tdl": True,
     "test-50-command-base64-empty.tdl": False,
     "test-51-disk-size.tdl": True,
+    "test-52-command-file-url.tdl": True,
+    "test-53-command-http-url.tdl": True,
+    "test-54-files-file-url.tdl": True,
+    "test-55-files-http-url.tdl": True,
 }
 
 # Validate oz handling of tdl file


### PR DESCRIPTION
xml is quite sensitive to characters in <command> section.  It especially becomes painful when trying to include shell commands that use "<>\$"  and probably a few others.

or alternatively make the scripts standalone files and in the tdl the list of files.
