### PR TITLE
Break out of loop in _internal_generate_diskimage when pool found

### DIFF
--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -541,6 +541,7 @@ class Guest(object):
                 if not pool.isActive():
                     pool.create(0)
                     started = True
+                break
 
         if not found:
             pool = self.libvirt_conn.storagePoolCreateXML(pool_xml, 0)


### PR DESCRIPTION
Otherwise, if the correct pool was not the last item in the array, it
would get replaced with the last array item and later libvirt would
fail to find the disk image (since it was in the wrong pool).
