### PR TITLE
Use one write with heredocs and move to the with statement as per PEP343

### DIFF
--- a/oz/Debian.py
+++ b/oz/Debian.py
@@ -72,21 +72,22 @@ class DebianGuest(oz.Guest.CDGuest):
             installdir = "/install.386"
 
         self.log.debug("Modifying isolinux.cfg")
-        isolinuxcfg = os.path.join(self.iso_contents, "isolinux",
-                                   "isolinux.cfg")
-        f = open(isolinuxcfg, 'w')
-        f.write("default customiso\n")
-        f.write("timeout 1\n")
-        f.write("prompt 0\n")
-        f.write("label customiso\n")
-        f.write("  menu label ^Customiso\n")
-        f.write("  menu default\n")
-        f.write("  kernel " + installdir + "/vmlinuz\n")
+        isolinuxcfg = os.path.join(self.iso_contents, "isolinux", "isolinux.cfg")
         extra = ""
         if self.tdl.update in ["7"]:
             extra = "auto=true "
-        f.write("  append file=/cdrom/preseed/customiso.seed " + extra + "debian-installer/locale=en_US console-setup/layoutcode=us netcfg/choose_interface=auto priority=critical initrd=" + installdir + "/initrd.gz --\n")
-        f.close()
+
+        with open(isolinuxcfg, 'w') as f:
+            f.write("""\
+default customiso
+timeout 1
+prompt 0
+label customiso
+  menu label ^Customiso
+  menu default
+  kernel %s/vmlinuz
+  append file=/cdrom/preseed/customiso.seed %sdebian-installer/locale=en_US console-setup/layoutcode=us netcfg/choose_interface=auto priority=critical initrd=%s/initrd.gz --
+""" % installdir, extra, installdir)
 
     def _generate_new_iso(self):
         """

--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -1395,7 +1395,8 @@ class Guest(object):
 
             key.save_key(privname, cipher=None)
             os.chmod(privname, 0o600)
-            open(pubname, 'w').write(keystring)
+            with open(pubname, 'w') as f:
+                f.write(keystring)
             os.chmod(pubname, 0o644)
 
 class CDGuest(Guest):
@@ -1663,9 +1664,8 @@ class CDGuest(Guest):
         eltoritodata = cdfd.read(count*512)
         cdfd.close()
 
-        out = open(outfile, "w")
-        out.write(eltoritodata)
-        out.close()
+        with open(outfile, "w") as f
+            f.write(eltoritodata)
 
     def _do_install(self, timeout=None, force=False, reboots=0,
                     kernelfname=None, ramdiskfname=None, cmdline=None):

--- a/oz/Mandrake.py
+++ b/oz/Mandrake.py
@@ -68,14 +68,15 @@ class MandrakeGuest(oz.Guest.CDGuest):
         self.log.debug("Modifying isolinux.cfg")
         isolinuxcfg = os.path.join(self.iso_contents, "isolinux",
                                    "isolinux.cfg")
-        f = open(isolinuxcfg, 'w')
-        f.write("default customiso\n")
-        f.write("timeout 1\n")
-        f.write("prompt 0\n")
-        f.write("label customiso\n")
-        f.write("  kernel alt0/vmlinuz\n")
-        f.write("  append initrd=alt0/all.rdz ramdisk_size=128000 root=/dev/ram3 acpi=ht vga=788 automatic=method:cdrom kickstart=auto_inst.cfg\n")
-        f.close()
+        with open(isolinuxcfg, 'w') as f:
+            f.write("""\
+default customiso
+timeout 1
+prompt 0
+label customiso
+  kernel alt0/vmlinuz
+  append initrd=alt0/all.rdz ramdisk_size=128000 root=/dev/ram3 acpi=ht vga=788 automatic=method:cdrom kickstart=auto_inst.cfg
+""")
 
     def _generate_new_iso(self):
         """
@@ -127,15 +128,15 @@ class Mandrake82Guest(oz.Guest.CDGuest):
             shutil.copy(self.auto, outname)
 
         syslinux = os.path.join(self.icicle_tmp, 'syslinux.cfg')
-        f = open(syslinux, 'w')
-        f.write("default customiso\n")
-        f.write("timeout 1\n")
-        f.write("prompt 0\n")
-        f.write("label customiso\n")
-        f.write("  kernel vmlinuz\n")
-        f.write("  append initrd=cdrom.rdz ramdisk_size=32000 root=/dev/ram3 automatic=method:cdrom vga=788 auto_install=auto_inst.cfg\n")
-        f.close()
-
+        with open(syslinux, 'w') as f:
+            f.write("""\
+default customiso
+timeout 1
+prompt 0
+label customiso
+  kernel vmlinuz
+  append initrd=cdrom.rdz ramdisk_size=32000 root=/dev/ram3 automatic=method:cdrom vga=788 auto_install=auto_inst.cfg
+""")
         cdromimg = os.path.join(self.iso_contents, "Boot", "cdrom.img")
         oz.ozutil.subprocess_check_output(["mcopy", "-n", "-o", "-i",
                                            cdromimg, syslinux,

--- a/oz/Mandriva.py
+++ b/oz/Mandriva.py
@@ -73,14 +73,15 @@ class MandrivaGuest(oz.Guest.CDGuest):
 
         self.log.debug("Modifying isolinux.cfg")
         isolinuxcfg = os.path.join(pathdir, "isolinux", "isolinux.cfg")
-        f = open(isolinuxcfg, 'w')
-        f.write("default customiso\n")
-        f.write("timeout 1\n")
-        f.write("prompt 0\n")
-        f.write("label customiso\n")
-        f.write("  kernel alt0/vmlinuz\n")
-        f.write("  append initrd=alt0/all.rdz ramdisk_size=128000 root=/dev/ram3 acpi=ht vga=788 automatic=method:cdrom kickstart=auto_inst.cfg\n")
-        f.close()
+        with open(isolinuxcfg, 'w') as f:
+            f.write("""\
+default customiso
+timeout 1
+prompt 0
+label customiso
+  kernel alt0/vmlinuz
+  append initrd=alt0/all.rdz ramdisk_size=128000 root=/dev/ram3 acpi=ht vga=788 automatic=method:cdrom kickstart=auto_inst.cfg
+""")
 
     def _generate_new_iso(self):
         """

--- a/oz/RHEL_3.py
+++ b/oz/RHEL_3.py
@@ -44,8 +44,8 @@ class RHEL3Guest(oz.RedHat.RedHatCDGuest):
                                          None, macaddress)
 
         # override the sshd_config value set in RedHatCDGuest.__init__
-        self.sshd_config = \
-"""SyslogFacility AUTHPRIV
+        self.sshd_config = """\
+SyslogFacility AUTHPRIV
 PasswordAuthentication yes
 ChallengeResponseAuthentication no
 X11Forwarding yes

--- a/oz/RHEL_4.py
+++ b/oz/RHEL_4.py
@@ -58,9 +58,8 @@ class RHEL4Guest(oz.RedHat.RedHatCDGuest):
         install RHEL-4/CentOS-4 since it requires a switch during install,
         which we cannot detect).
         """
-        cdfd = open(self.orig_iso, "r")
-        pvd = self._get_primary_volume_descriptor(cdfd)
-        cdfd.close()
+        with open(self.orig_iso, "r") as cdfd:
+            pvd = self._get_primary_volume_descriptor(cdfd)
 
         # all of the below should have "LINUX" as their system_identifier,
         # so check it here

--- a/oz/RHEL_5.py
+++ b/oz/RHEL_5.py
@@ -59,9 +59,8 @@ class RHEL5Guest(oz.RedHat.RedHatCDYumGuest):
         install RHEL-5/CentOS-5 since it requires a switch during install,
         which we cannot detect).
         """
-        cdfd = open(self.orig_iso, "r")
-        pvd = self._get_primary_volume_descriptor(cdfd)
-        cdfd.close()
+        with open(self.orig_iso, "r") as cdfd:
+            pvd = self._get_primary_volume_descriptor(cdfd)
 
         # all of the below should have "LINUX" as their system_identifier,
         # so check it here

--- a/oz/ozutil.py
+++ b/oz/ozutil.py
@@ -891,11 +891,10 @@ def _gzip_file(inputfile, outputfile, outputmode):
     output file, and if the outputmode is 'wb' then the input file will be
     written over the output file.
     """
-    f = open(inputfile, 'rb')
-    gzf = gzip.GzipFile(outputfile, mode=outputmode)
-    gzf.writelines(f)
-    gzf.close()
-    f.close()
+    with open(inputfile, 'rb') as f:
+        gzf = gzip.GzipFile(outputfile, mode=outputmode)
+        gzf.writelines(f)
+        gzf.close()
 
 def gzip_append(inputfile, outputfile):
     """


### PR DESCRIPTION
This takes the multiline writes and `with` cleanups from #75 as mentioned in the last comment.

To answer the question when `with` was added then PEP343 (http://www.python.org/dev/peps/pep-0343/) describes the `with` keyword and was added to Python 2.5 (http://effbot.org/zone/python-with-statement.htm) as a future statement and moved into normal namespace in 2.6 (http://docs.python.org/2/whatsnew/2.6.html#pep-343-the-with-statement)

So depending on how far back you want to support Python versions?

Additionally I changed all the `f` variables to `handle` after pylint complained at me but then I realised I hadn't loaded the oz pylint config - Do you want me to fix it all back to `f`?

Took longer than I thought to get this going, sorry for the delay.
