### PR TITLE
Add the ability to generate ICICLE safely

### DIFF
--- a/oz.cfg
+++ b/oz.cfg
@@ -15,3 +15,6 @@ image_type = raw
 original_media = yes
 modified_media = no
 jeos = no
+
+[icicle]
+safe_generation = no

--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -183,6 +183,12 @@ class Guest(object):
 
         self.jeos_cache_dir = os.path.join(self.data_dir, "jeos")
 
+        # configuration of "safe" ICICLE generation option
+        self.safe_icicle_gen = oz.ozutil.config_get_boolean_key(config,
+                                                                'icicle',
+                                                                'safe_generation',
+                                                                False)
+
         # only pull a cached JEOS if it was built with the correct image type
         if self.image_type == 'raw':
             # backwards compatible
@@ -504,9 +510,14 @@ class Guest(object):
         return xml
 
     def _internal_generate_diskimage(self, size=10, force=False,
-                                     create_partition=False):
+                                     create_partition=False,
+                                     image_filename=None,
+                                     backing_filename=None):
         """
         Internal method to generate a diskimage.
+        Set image_filename to override the default selection of self.diskimage
+        Set backing_filename to force diskimage to be a writeable qcow2 snapshot
+        backed by "backing_filename" which can be either a raw image or a qcow2 image
         """
         if not force and os.access(self.jeos_filename, os.F_OK):
             # if we found a cached JEOS, we don't need to do anything here;
@@ -516,8 +527,12 @@ class Guest(object):
         self.log.info("Generating %dGB diskimage for %s" % (size,
                                                             self.tdl.name))
 
-        directory = os.path.dirname(self.diskimage)
-        filename = os.path.basename(self.diskimage)
+        if image_filename:
+            diskimage = image_filename
+        else:
+            diskimage = self.diskimage
+        directory = os.path.dirname(diskimage)
+        filename = os.path.basename(diskimage)
 
         doc = libxml2.newDoc("1.0")
         pool = doc.newChild(None, "pool", None)
@@ -532,11 +547,32 @@ class Guest(object):
         vol.setProp("type", "file")
         vol.newChild(None, "name", filename)
         vol.newChild(None, "allocation", "0")
-        cap = vol.newChild(None, "capacity", str(size))
-        cap.setProp("unit", "G")
         target = vol.newChild(None, "target", None)
         fmt = target.newChild(None, "format", None)
-        fmt.setProp("type", self.image_type)
+        if backing_filename:
+            # TODO: Revisit as BZ 958510 evolves
+            # At the moment libvirt forces us to specify a size rather than assuming we want to
+            # inherit the size of our backing file.
+            # It may be possible to avoid this inspection step if libvirt allow creation without
+            # an explicit capacity element.
+            qcow_size = oz.ozutil.check_qcow_size(backing_filename)
+            if qcow_size:
+                capacity = qcow_size
+                backing_format = 'qcow2'
+            else:
+                capacity = os.path.getsize(backing_filename)
+                backing_format = 'raw'
+            fmt.setProp("type", "qcow2")
+            backstore = vol.newChild(None, "backingStore", None)
+            backstore.newChild(None, "path", backing_filename)
+            backfmt = backstore.newChild(None, "format", None)
+            backfmt.setProp("type", backing_format)
+            cap = vol.newChild(None, "capacity", str(capacity))
+            cap.setProp("unit", "B")
+        else:
+            fmt.setProp("type", self.image_type)
+            cap = vol.newChild(None, "capacity", str(size))
+            cap.setProp("unit", "G")
         # FIXME: this makes the permissions insecure, but is needed since
         # libvirt launches guests as qemu:qemu.
         permissions = target.newChild(None, "permissions", None)
@@ -592,7 +628,9 @@ class Guest(object):
             if started:
                 pool.destroy()
 
-        if create_partition:
+        if create_partition and backing_filename:
+            self.log.warning("Asked to create partition against a copy-on-write snapshot - ignoring")
+        elif create_partition:
             g_handle = guestfs.GuestFS()
             g_handle.add_drive_opts(self.diskimage, format=self.image_type, readonly = 0)
             g_handle.launch()
@@ -1123,6 +1161,35 @@ class Guest(object):
             raise oz.OzException.OzException("%d devices sections specified, something is wrong with the libvirt XML" % (devlen))
 
         self._generate_serial_xml(devices[0])
+
+        xml = input_doc.serialize(None, 1)
+        self.log.debug("Generated XML:\n%s" % (xml))
+        return xml
+
+    def _modify_libvirt_xml_diskimage(self, libvirt_xml, new_diskimage, image_type):
+        """
+        Internal method to take input libvirt XML and replace the existing disk image
+        details with a new disk image file and, potentially, disk image type.  Used in
+        safe ICICLE generation to replace the "real" disk image file with a temporary
+        writeable snapshot.
+        """
+        self.log.debug("Modifying libvirt XML to use disk image (%s) of type (%s)" % (new_diskimage, image_type))
+        input_doc = libxml2.parseDoc(libvirt_xml)
+        disks = input_doc.xpathEval('/domain/devices/disk')
+        if len(disks) != 1:
+            self.log.warning("Oz given a libvirt domain with more than 1 disk; using the first one parsed")
+
+        source = disks[0].xpathEval('source')
+        if len(source) != 1:
+            raise oz.OzException.OzException("invalid <disk> entry without a source")
+        source[0].setProp('file', new_diskimage)
+
+        driver = disks[0].xpathEval('driver')
+        # at the time this function was added, all boot disk device stanzas have a driver section - even raw images
+        if len(driver) == 1:
+            driver[0].setProp('type', image_type)
+        else:
+            raise oz.OzException.OzException("Found a disk with an unexpected number of driver sections")
 
         xml = input_doc.serialize(None, 1)
         self.log.debug("Generated XML:\n%s" % (xml))

--- a/oz/RedHat.py
+++ b/oz/RedHat.py
@@ -23,6 +23,7 @@ import re
 import os
 import shutil
 import libvirt
+import libxml2
 try:
     import configparser
 except ImportError:
@@ -1126,9 +1127,20 @@ class RedHatCDYumGuest(RedHatCDGuest):
 
         self.log.info("Customizing image")
 
-        if not self.tdl.packages and not self.tdl.files and not self.tdl.commands and action == "mod_only":
-            self.log.info("No additional packages, files, or commands to install, and icicle generation not requested, skipping customization")
-            return
+        if not self.tdl.packages and not self.tdl.files and not self.tdl.commands:
+            if action == "mod_only":
+                self.log.info("No additional packages, files, or commands to install, and icicle generation not requested, skipping customization")
+                return
+            elif action == "gen_and_mod":
+                # It is actually possible to get here with a "gen_and_mod"
+                # action but a TDL that contains no real customizations
+                # In the "safe ICICLE" code below it is important to know
+                # when we are truly in a "gen_only" state so we modify
+                # the action here if we detect that ICICLE generation is the
+                # only task to be done.
+                # TODO: See about doing this test earlier or in a more generic way
+                self.log.debug("Asked to gen_and_mod but no mods are present - changing action to gen_only")
+                action = "gen_only"
 
         # when doing an oz-install with -g, this isn't necessary as it will
         # just replace the port with the same port.  However, it is very
@@ -1136,6 +1148,16 @@ class RedHatCDYumGuest(RedHatCDGuest):
         # not match what is specified in the libvirt XML
         modified_xml = self._modify_libvirt_xml_for_serial(libvirt_xml)
 
+        if action == "gen_only" and self.safe_icicle_gen:
+            # We are only generating ICICLE and the user has asked us to do this without modifying
+            # the completed image by booting it.
+            # Create a copy on write snapshot to use for ICICLE generation - discard when finished
+            cow_diskimage = self.diskimage + "-icicle-snap.qcow2"
+            self._internal_generate_diskimage(force=True,
+                                              backing_filename=self.diskimage,
+                                              image_filename=cow_diskimage)
+            modified_xml = self._modify_libvirt_xml_diskimage(modified_xml, cow_diskimage, 'qcow2')
+ 
         self._collect_setup(modified_xml)
 
         icicle = None
@@ -1159,7 +1181,11 @@ class RedHatCDYumGuest(RedHatCDGuest):
             finally:
                 self._shutdown_guest(guestaddr, libvirt_dom)
         finally:
-            self._collect_teardown(modified_xml)
+            if action == "gen_only" and self.safe_icicle_gen:
+                # no need to teardown because we simply discard the file containing those changes
+                os.unlink(cow_diskimage)
+            else:
+                self._collect_teardown(modified_xml)
 
         return icicle
 

--- a/oz/ozutil.py
+++ b/oz/ozutil.py
@@ -34,6 +34,7 @@ except ImportError:
     import ConfigParser as configparser
 import collections
 import ftplib
+import struct
 
 def generate_full_auto_path(relative):
     """
@@ -895,3 +896,40 @@ def gzip_create(inputfile, outputfile):
         if os.access(outputfile, os.F_OK):
             os.unlink(outputfile)
         raise
+
+def check_qcow_size(filename):
+    # Detect if an image is in qcow format
+    # If it is, return the size of the underlying disk image
+    # If it isn't, return none
+
+    # For interested parties, this is the QCOW header struct in C
+    # struct qcow_header {
+    #    uint32_t magic; 
+    #    uint32_t version;
+    #    uint64_t backing_file_offset;
+    #    uint32_t backing_file_size;
+    #    uint32_t cluster_bits;
+    #    uint64_t size; /* in bytes */
+    #    uint32_t crypt_method;
+    #    uint32_t l1_size;
+    #    uint64_t l1_table_offset;
+    #    uint64_t refcount_table_offset;
+    #    uint32_t refcount_table_clusters;
+    #    uint32_t nb_snapshots;
+    #    uint64_t snapshots_offset;
+    # };
+
+    # And in Python struct format string-ese
+    qcow_struct=">IIQIIQIIQQIIQ" # > means big-endian
+    qcow_magic = 0x514649FB # 'Q' 'F' 'I' 0xFB
+
+    f = open(filename,"r")
+    pack = f.read(struct.calcsize(qcow_struct))
+    f.close()
+
+    unpack = struct.unpack(qcow_struct, pack)
+
+    if unpack[0] == qcow_magic:
+	return unpack[5]
+    else:
+	return None


### PR DESCRIPTION
This patch allows users to generate ICICLE while preserving the
pristine content of the original image generated by the native
installer.  This avoids embedding the results of "first boot" type
tasks such as the generation of SSH keys and the initialization of
log files.

This is particularly useful when generating images for cloud targets
using custom install scripts and no customization in the TDL itself.

It works by running the ICICLE step against a temporary qcow2 disk
image which uses the "real" image as a backing store.  All writes
are done to the qcow2 image which is discarded when ICICLE generation
is complete.

This features is a new option in the config file and is disabled
by default.

For the moment it only works with RPM/Anaconda distros but could
likely be extended to support any OS for which ICICLE can be generated.
