### PR TITLE
preserve original order of package list used for ICICLE generation

### DIFF
--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -1291,7 +1291,6 @@ class Guest(object):
             description = icicle.newChild(None, "description", description)
         packages = icicle.newChild(None, "packages", None)
 
-        lines.sort()
         for index,line in enumerate(lines):
             if line == "":
                 continue


### PR DESCRIPTION
Sorting the default format package list destroys the 1:1 match between it
and any optional extra list, at least for RPM based operating systems.
This also has the unintended side effect of producing a blank <extra> tag for
the final package in the list.
As the sorting is purely cosmetic, and can easily be done on the receiving end
for clients that desire it, just remove it here to address both issues.
