### PR TITLE
use unique name when creating temporary storage pool

### DIFF
--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -545,7 +545,7 @@ class Guest(object):
         doc = libxml2.newDoc("1.0")
         pool = doc.newChild(None, "pool", None)
         pool.setProp("type", "dir")
-        pool.newChild(None, "name", "oztempdir")
+        pool.newChild(None, "name", "oztempdir-" + str(uuid.uuid4()) )
         target = pool.newChild(None, "target", None)
         target.newChild(None, "path", directory)
         pool_xml = doc.serialize(None, 1)


### PR DESCRIPTION
If Oz is being used concurrently with two distinct directories and target
images it can still fail because of duplication of the temp storage pool
name (oztempdir).  There is code elsewhere in Guest.py that tries to detect
if a pool already exists for the same directory, independent of the name.

So, just create a unique name each time.
