### PR TITLE
Removed hardcoded paths to private key

### DIFF
--- a/man/oz-cleanup-cache.1
+++ b/man/oz-cleanup-cache.1
@@ -52,6 +52,7 @@ The configuration file should have the following form:
 output_dir = /var/lib/libvirt/images
 data_dir = /var/lib/oz
 screenshot_dir = .
+sshprivkey = /etc/oz/id_rsa-icicle-ge
 
 [libvirt]
 uri = qemu:///system
@@ -77,7 +78,8 @@ built, and the \fBdata_dir\fR key describes where to cache install media and
 use temporary storage.  Both locations must have a decent amount of
 free disk space in order for Oz to work properly.
 The \fBscreenshot_dir\fR key describes where to store screenshots of
-failed installs.
+failed installs. The \fBsshprivkey\fR key describes where the ssh keys are
+stored, they are required by Oz depending on the guest operating system. 
 
 The \fBlibvirt\fR section allows some manipulation of how Oz uses libvirt.
 The \fBuri\fR key describes the libvirt URI to use to do the guest

--- a/man/oz-customize.1
+++ b/man/oz-customize.1
@@ -54,6 +54,7 @@ The configuration file should have the following form:
 output_dir = /var/lib/libvirt/images
 data_dir = /var/lib/oz
 screenshot_dir = .
+sshprivkey = /etc/oz/id_rsa-icicle-gen
 
 [libvirt]
 uri = qemu:///system
@@ -79,7 +80,8 @@ built, and the \fBdata_dir\fR key describes where to cache install media and
 use temporary storage.  Both locations must have a decent amount of
 free disk space in order for Oz to work properly.
 The \fBscreenshot_dir\fR key describes where to store screenshots of
-failed installs.
+failed installs. The \fBsshprivkey\fR key describes where the ssh keys are
+stored, they are required by Oz depending on the guest operating system.
 
 The \fBlibvirt\fR section allows some manipulation of how Oz uses libvirt.
 The \fBuri\fR key describes the libvirt URI to use to do the guest

--- a/man/oz-generate-icicle.1
+++ b/man/oz-generate-icicle.1
@@ -58,6 +58,7 @@ The configuration file should have the following form:
 output_dir = /var/lib/libvirt/images
 data_dir = /var/lib/oz
 screenshot_dir = .
+sshprivkey = /etc/oz/id_rsa-icicle-gen
 
 [libvirt]
 uri = qemu:///system
@@ -83,7 +84,8 @@ built, and the \fBdata_dir\fR key describes where to cache install media and
 use temporary storage.  Both locations must have a decent amount of
 free disk space in order for Oz to work properly.
 The \fBscreenshot_dir\fR key describes where to store screenshots of
-failed installs.
+failed installs. The \fBsshprivkey\fR key describes where the ssh keys are
+stored, they are required by Oz depending on the guest operating system.
 
 The \fBlibvirt\fR section allows some manipulation of how Oz uses libvirt.
 The \fBuri\fR key describes the libvirt URI to use to do the guest

--- a/man/oz-install.1
+++ b/man/oz-install.1
@@ -132,6 +132,7 @@ The configuration file should have the following form:
 output_dir = /var/lib/libvirt/images
 data_dir = /var/lib/oz
 screenshot_dir = .
+sshprivkey = /etc/oz/id_rsa-icicle-ge
 
 [libvirt]
 uri = qemu:///system
@@ -157,7 +158,8 @@ built, and the \fBdata_dir\fR key describes where to cache install media and
 use temporary storage.  Both locations must have a decent amount of
 free disk space in order for Oz to work properly.
 The \fBscreenshot_dir\fR key describes where to store screenshots of
-failed installs.
+failed installs. The \fBsshprivkey\fR key describes where the ssh keys are
+stored, they are required by Oz depending on the guest operating system.
 
 The \fBlibvirt\fR section allows some manipulation of how Oz uses libvirt.
 The \fBuri\fR key describes the libvirt URI to use to do the guest

--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -161,6 +161,10 @@ class Guest(object):
                                                        'screenshot_dir',
                                                        oz.ozutil.default_screenshot_dir(self.data_dir))
 
+        self.sshprivkey = oz.ozutil.config_get_key(config, 'paths',
+                                                       'sshprivkey',
+                                                       oz.ozutil.default_sshprivkey())
+
         # configuration from 'libvirt' section
         self.libvirt_uri = oz.ozutil.config_get_key(config, 'libvirt', 'uri',
                                                     'qemu:///system')

--- a/oz/OpenSUSE.py
+++ b/oz/OpenSUSE.py
@@ -45,8 +45,6 @@ class OpenSUSEGuest(oz.Guest.CDGuest):
             # for 10.3 we don't have a 2-stage install process so don't reboot
             self.reboots = 0
 
-        self.sshprivkey = os.path.join('/etc', 'oz', 'id_rsa-icicle-gen')
-
     def _modify_iso(self):
         """
         Method to make the boot ISO auto-boot with appropriate parameters.

--- a/oz/RedHat.py
+++ b/oz/RedHat.py
@@ -45,7 +45,6 @@ class RedHatCDGuest(oz.Guest.CDGuest):
         oz.Guest.CDGuest.__init__(self, tdl, config, auto, output_disk,
                                   nicmodel, None, None, diskbus, iso_allowed,
                                   url_allowed, macaddress)
-        self.sshprivkey = os.path.join('/etc', 'oz', 'id_rsa-icicle-gen')
         self.crond_was_active = False
         self.sshd_was_active = False
         self.sshd_config = \

--- a/oz/Ubuntu.py
+++ b/oz/Ubuntu.py
@@ -40,7 +40,6 @@ class UbuntuGuest(oz.Guest.CDGuest):
                                   nicmodel, None, None, diskbus, True, True,
                                   macaddress)
 
-        self.sshprivkey = os.path.join('/etc', 'oz', 'id_rsa-icicle-gen')
         self.crond_was_active = False
         self.sshd_was_active = False
         self.sshd_config = \

--- a/oz/ozutil.py
+++ b/oz/ozutil.py
@@ -735,6 +735,17 @@ def default_data_dir():
 
     return os.path.expanduser(directory)
 
+def default_sshprivkey():
+    """
+    Function to get the default path to the SSH private key.
+    """
+    if os.geteuid() == 0:
+        directory = "/etc/oz/id_rsa-icicle-gen"
+    else:
+        directory = "~/.oz/id_rsa-icicle-gen"
+
+    return os.path.expanduser(directory)
+
 def default_screenshot_dir(data_dir):
     """
     Function to get the default path to the screenshot directory. The directory is


### PR DESCRIPTION
Without this patch, the hardcoded path of the private key prevents to perform non-root executions of Oz, getting the following error:

```
DEBUG:oz.Guest.RHEL6Guest:Testing ssh connection
Enter passphrase for key '/etc/oz/id_rsa-icicle-gen': 
```

The proposed patch gets this information from oz.cfg adding a new parameter 'sshprivkey' that defaults to '/etc/oz/id_rsa-icicle-gen'
