### PR TITLE
Use --yes on add-apt-repository so it is possible to use PPAs

### DIFF
--- a/oz/Ubuntu.py
+++ b/oz/Ubuntu.py
@@ -531,7 +531,7 @@ Subsystem       sftp    /usr/libexec/openssh/sftp-server
         self.log.debug("Installing additional repository files")
 
         for repo in list(self.tdl.repositories.values()):
-            self.guest_execute_command(guestaddr, "apt-add-repository '%s'" % (repo.url.strip('\'"')))
+            self.guest_execute_command(guestaddr, "apt-add-repository --yes '%s'" % (repo.url.strip('\'"')))
             self.guest_execute_command(guestaddr, "apt-get update")
 
     def do_customize(self, guestaddr):


### PR DESCRIPTION
add-apt-repository ppa:nginx/stable asks if we want to continue or not because the command lacks --yes. Given we are using -y for installation and similar operation we should try to stay consistent.
