### PR TITLE
Mageia multi

### DIFF
--- a/examples/MageiaStack.auto
+++ b/examples/MageiaStack.auto
@@ -1,0 +1,141 @@
+#!/usr/bin/perl -cw
+#
+# You should check the syntax of this file before using it in an auto-install.
+# You can do this with 'perl -cw auto_inst.cfg.pl' or by executing this file
+# (note the '#!/usr/bin/perl -cw' on the first line).
+$o = {
+       'autoExitInstall' => '1',
+       'interactiveSteps' => [],
+       'no_suggests' => 1,
+       'mkbootdisk' => 0,
+       'isUpgrade' => 0,
+       'excludedocs' => 1,
+       'minimal' => 1,
+       'miscellaneous' => {
+	   'numlock' => 1,
+       },
+
+       'netc' => {
+		   'ZEROCONF_HOSTNAME' => undef,
+		   'NETWORKING' => 'yes',
+		   'NET_DEVICE' => 'eth0',
+		   'DHCP' => 'yes'
+		 },
+       'locale' => {
+		     'lang' => 'en_US',
+		     'country' => 'US',
+		     'utf8' => 1,
+		     'langs' => {
+				  'en_US' => 1
+				}
+		   },
+       'mkbootdisk' => 0,
+       'partitions' => [
+			 {
+                           'size' => 1024,
+			   'ratio' => 100,
+			   'mntpoint' => '/',
+			   'type' => 1155,
+			   'fs_type' => 'ext4'
+			 }
+		       ],
+       'printer' => {
+		      'MANUALCUPSCONFIG' => undef,
+		      'BROWSEPOLLPORT' => undef,
+		      'BROWSEPOLLADDR' => undef,
+		      'SPOOLER' => undef,
+		      'configured' => {},
+		      'DEFAULT' => undef
+		    },
+       'intf' => {
+		   'eth0' => {
+			       'BROADCAST' => '',
+			       'ONBOOT' => 'yes',
+			       'BOOTPROTO' => 'dhcp',
+			       'DEVICE' => 'eth0',
+			       'NETMASK' => '255.255.255.0',
+			       'NETWORK' => ''
+			     }
+		 },
+       'authentication' => {
+			     'shadow' => 1,
+			     'md5' => 1,
+			     'local' => undef
+			   },
+       'partitioning' => {
+			   'auto_allocate' => '1',
+			   'clearall' => '1',
+			   'eraseBadPartitions' => 0
+			 },
+       'users' => [{
+'icon' => 'default',
+'realname' => 'Mageia Cloud User',
+'uid' => undef,
+'groups' => [],
+'name' => 'mageia',
+'shell' => '/bin/bash',
+'password' => 'cubswin:)',
+'gid' => undef
+}],
+       'security' => 2,
+       'X' => { disabled => 1 },
+       'skipped_packages' => [ 'xdm', 'shorewall',
+			       'shorewall-core', 'mageia-gfxboot-theme', 'grub', 
+			       'rsyslog', 'acpid', 'acpi', 'cpupower', 'mandi', 'mandi-ifw'],
+       'default_packages' => [
+			       'basesystem-minimal',
+	                       'urpmi',
+                               'sudo', 'grub2',
+	                       'openssh-client',
+                               'openssh-server', 'vim-minimal',
+	   "cloud-utils",
+	   "cloud-init",
+           "cloud-initramfs-tools"],
+       'superuser' => {
+			'home' => '/root',
+			'shell' => '/bin/bash',
+			'realname' => 'root',
+			'password' => 'cubswin:)',
+			'uid' => '0',
+			'gid' => '0'
+		      },
+       'manualFstab' => [],
+       'libsafe' => 0,
+       'useSupermount' => '0',
+       'timezone' => {
+		       'UTC' => 1,
+		       'ntp' => undef,
+		       'timezone' => 'America/New_York'
+		     },
+       'netcnx' => {
+		     'lan' => {},
+		     'type' => 'lan'
+		   },
+       'keyboard' => {
+		       'unsafe' => 1,
+		       'GRP_TOGGLE' => '',
+		       'KEYBOARD' => 'us',
+		       'KBCHARSET' => 'C'
+		     },
+       'security_user' => '',
+       'mouse' => {
+		    'MOUSETYPE' => 'ps/2',
+		    'device' => 'psaux',
+		    'name' => 'Standard',
+		    'nbuttons' => 2,
+		    'type' => 'PS/2',
+		    'XMOUSETYPE' => 'PS/2',
+		    'EMULATEWHEEL' => undef
+		  },
+			'postInstall' => '
+rm -rf /etc/udev/rules.d/70-persistent-net.rules
+touch /etc/udev/rules.d/70-persistent-net.rules
+cat <<EOP >> /etc/rc.d/init.d/mandrake_everytime
+echo "login as user mageia password cubswin:)" >> /etc/issue
+EOP
+cat <<EOP >> /etc/default/grub
+GRUB_CMDLINE_LINUX_DEFAULT="console=ttyS0"
+EOP
+update-grub2
+'
+     };

--- a/examples/mageiaiso.tdl
+++ b/examples/mageiaiso.tdl
@@ -1,0 +1,15 @@
+<!-- An example that shows how to do a basic install of Mageia 4
+     x86_64 using the ISO type install from a local file.
+-->
+<template>
+  <name>Mageia</name>
+  <os>
+    <name>Mageia</name>
+    <version>4</version>
+    <arch>x86_64</arch>
+    <install type='iso'>
+      <iso>file:///home/joe/git/oz/Mageia-4-alpha2-x86_64-DVD.iso</iso>
+    </install>
+  </os>
+  <description>Mageia 4</description>
+</template>

--- a/examples/mageianet.tdl
+++ b/examples/mageianet.tdl
@@ -1,0 +1,20 @@
+<!-- An example that shows how to do a basic install of Mageia 4
+     x86_64 using the ISO type install from network boot image
+-->
+<template>
+  <name>Mageia</name>
+  <os>
+    <name>Mageia</name>
+    <version>4</version>
+    <arch>x86_64</arch>
+    <install type='iso'>
+      <iso>http://ftp.tku.edu.tw/Linux/Mageia/distrib/cauldron/x86_64/install/images/boot-nonfree.iso</iso>
+    </install>
+  </os>
+  <repositories>
+  <repository name="install">
+  <url>http://ftp.tku.edu.tw/Linux/Mageia/distrib/cauldron/x86_64/</url>
+  </repository>
+  </repositories>
+  <description>Mageia 4</description>
+</template>

--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -471,7 +471,13 @@ class Guest(object):
         self.lxml_subelement(bootDisk, "source", None, {'file':self.diskimage})
         self.lxml_subelement(bootDisk, "driver", None, {'name':'qemu', 'type':self.image_type})
         # install disk (if any)
-        if installdev:
+        if not installdev:
+            installdev_list = []
+        elif not type(installdev) is list:
+            installdev_list = [installdev]
+        else:
+            installdev_list = installdev
+        for installdev in installdev_list:
             install = self.lxml_subelement(devices, "disk", None, {'type':'file', 'device':installdev.devicetype})
             self.lxml_subelement(install, "source", None, {'file':installdev.path})
             self.lxml_subelement(install, "target", None, {'dev':installdev.bus})
@@ -1626,7 +1632,8 @@ class CDGuest(Guest):
             f.write(eltoritodata)
 
     def _do_install(self, timeout=None, force=False, reboots=0,
-                    kernelfname=None, ramdiskfname=None, cmdline=None):
+                    kernelfname=None, ramdiskfname=None, cmdline=None,
+                    extrainstalldevs=None):
         """
         Internal method to actually run the installation.
         """
@@ -1641,7 +1648,9 @@ class CDGuest(Guest):
             timeout = 1200
 
         cddev = self._InstallDev("cdrom", self.output_iso, "hdc")
-
+        if extrainstalldevs != None:
+            extrainstalldevs.append(cddev)
+            cddev = extrainstalldevs
         reboots_to_go = reboots
         while reboots_to_go >= 0:
             # if reboots_to_go is the same as reboots, it means that this is

--- a/oz/Mageia.py
+++ b/oz/Mageia.py
@@ -39,6 +39,8 @@ class MageiaGuest(oz.Guest.CDGuest):
                  macaddress):
         if netdev is None:
             netdev = "virtio"
+        if diskbus is None:
+            diskbus = "virtio"
         oz.Guest.CDGuest.__init__(self, tdl, config, auto, output_disk, netdev,
                                   None, None, diskbus, True, False, macaddress)
 

--- a/oz/Mageia.py
+++ b/oz/Mageia.py
@@ -45,8 +45,6 @@ class MageiaGuest(oz.Guest.CDGuest):
                                   None, None, diskbus, True, False, macaddress)
 
         self.mageia_arch = self.tdl.arch
-        if self.mageia_arch == "i386":
-            self.mageia_arch = "i586"
         self.output_floppy = os.path.join(self.output_dir,
                                           self.tdl.name + "-" + self.tdl.installtype + "-oz.img")
 

--- a/oz/Mageia.py
+++ b/oz/Mageia.py
@@ -154,7 +154,7 @@ def get_class(tdl, config, auto, output_disk=None, netdev=None, diskbus=None,
     """
     Factory method for Mageia installs.
     """
-    if tdl.update in ["4"]:
+    if tdl.update in ["4", "cauldron"]:
         return MageiaGuest(tdl, config, auto, output_disk, netdev, diskbus,
                            macaddress)
 
@@ -162,4 +162,4 @@ def get_supported_string():
     """
     Return supported versions as a string.
     """
-    return "Mageia: 4"
+    return "Mageia: 4, cauldron"

--- a/oz/Mageia.py
+++ b/oz/Mageia.py
@@ -64,7 +64,7 @@ class MageiaGuest(oz.Guest.CDGuest):
         if not os.path.exists(pathdir):
             pathdir = self.iso_contents
 
-        outname = "/tmp/auto_inst.cfg"
+        outname = os.path.join(self.icicle_tmp, "auto_inst.cfg")
 
         if self.default_auto_file():
 


### PR DESCRIPTION
These patches allow for multi-device installs, in which more than one device is used for an install.  This allows it to support a mageia feature where there is a boot disk that overrides a CD rom.

It also fixes up the mageia build so that mageia can load an remote boot iso image.