### PR TITLE
Python 2.7 is the minimum dep for the required python-libvirt package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,16 +2,16 @@ Source: oz
 Maintainer: Richard Jones <rjones@redhat.com>
 Section: python
 Priority: optional
-Build-Depends: debhelper (>= 8.0.0), python-all (>= 2.6.6-3)
+Build-Depends: debhelper (>= 8.0.0), python-all (>= 2.7)
 Standards-Version: 3.9.4
 Homepage: http://aeolusproject.org/oz.html
 Vcs-Git: git://github.com/clalancette/oz.git
-X-Python-Version: >= 2.6
+X-Python-Version: >= 2.7
 
 Package: oz
 Architecture: all
 Depends: ${misc:Depends}, ${python:Depends},
- python (>= 2.5),
+ python (>= 2.7),
  genisoimage,
  libvirt-dev (>= 0.9.7),
  mtools,


### PR DESCRIPTION
Minimum (python-)libvirt requirement is 0.9.7

Only way to get that is via Ubuntu Precise or newer and requires Python 2.7
http://packages.ubuntu.com/precise-updates/python-libvirt

Lucid has older libvirt / python
http://packages.ubuntu.com/lucid-updates/python-libvirt

However both Debian Squeeze Backport and Wheezy have it available on 2.6
http://packages.debian.org/wheezy/python-libvirt
http://packages.debian.org/squeeze-backports/python-libvirt
