### PR TITLE
Improved Ubuntu repository add

### DIFF
--- a/oz/TDL.py
+++ b/oz/TDL.py
@@ -102,16 +102,32 @@ class Repository(object):
 
     name       - The name of this repository.
     url        - The URL of this repository.
+    (all remaining properties are optional with defaults in parentheses)
+    (yum specific)
     signed     - Whether this repository is signed
     persisted  - Whether this repository should remain in the final image
     sslverify  - Whether SSL certificates should be verified
+    (apt specific)
+    distribution - Determines from with location of the mirror to download from (OS short name)
+    components   - Components of the repository to access, more than one is accepted (main)
+    keyserver    - Which GPG key server to use (None)
+    key          - Which GPG key packages are signed with (None)
+    trusted      - Wether this repository is trusted, skips GPG checks if on (no)
+    arch         - Used for which architectures information should be downloaded (None)
     """
-    def __init__(self, name, url, signed, persisted, sslverify):
+    def __init__(self, name, url, signed, persisted, sslverify,
+                 distribution, components, keyserver, key, trusted, arch):
         self.name = name
         self.url = url
         self.signed = signed
         self.persisted = persisted
         self.sslverify = sslverify
+        self.distribution = distribution
+        self.components = components
+        self.keyserver = keyserver
+        self.key = key
+        self.trusted = trusted
+        self.arch = arch
 
 class Package(object):
     """
@@ -478,15 +494,26 @@ class TDL(object):
                                              "localhost.localdomain"]:
                 raise oz.OzException.OzException("Repositories cannot be localhost, since they must be reachable from the guest operating system")
 
+            # yum specific
             signed = _get_optional_repo_bool(repo, 'signed', 'no')
-
             persist = _get_optional_repo_bool(repo, 'persisted', 'yes')
-
             sslverify = _get_optional_repo_bool(repo, 'sslverify', 'no')
+
+            # apt specific
+            distribution = _xml_get_value(repo, 'distribution', 'distribution', optional=True)
+            components = _xml_get_value(repo, 'components', 'components', optional=True)
+            keyserver = _xml_get_value(repo, 'keyserver', 'keyserver', optional=True)
+            key = _xml_get_value(repo, 'key', 'key', optional=True)
+            trusted = _get_optional_repo_bool(repo, 'trusted', 'no')
+            arch = _xml_get_value(repo, 'arch', 'arch', optional=True)
+
+            if keyserver and not key:
+                raise oz.OzException.OzException('A key is required with keyserver')
 
             # no need to delete - if the name matches we just overwrite here
             self.repositories[name] = Repository(name, url, signed, persist,
-                                                 sslverify)
+                                                 sslverify, distribution, components,
+                                                 keyserver, key, trusted, arch)
 
     def _add_isoextras(self, extraspath, element_type):
         """

--- a/oz/TDL.py
+++ b/oz/TDL.py
@@ -114,9 +114,10 @@ class Repository(object):
     key          - Which GPG key packages are signed with (None)
     trusted      - Wether this repository is trusted, skips GPG checks if on (no)
     arch         - Used for which architectures information should be downloaded (None)
+    source       - If deb-src should be added to the list file as well (False)
     """
     def __init__(self, name, url, signed, persisted, sslverify,
-                 distribution, components, keyserver, key, trusted, arch):
+                 distribution, components, keyserver, key, trusted, arch, source):
         self.name = name
         self.url = url
         self.signed = signed
@@ -128,6 +129,7 @@ class Repository(object):
         self.key = key
         self.trusted = trusted
         self.arch = arch
+        self.source = source
 
 class Package(object):
     """
@@ -506,6 +508,7 @@ class TDL(object):
             key = _xml_get_value(repo, 'key', 'key', optional=True)
             trusted = _get_optional_repo_bool(repo, 'trusted', 'no')
             arch = _xml_get_value(repo, 'arch', 'arch', optional=True)
+            source = _get_optional_repo_bool(repo, 'source', 'no')
 
             if keyserver and not key:
                 raise oz.OzException.OzException('A key is required with keyserver')
@@ -513,7 +516,7 @@ class TDL(object):
             # no need to delete - if the name matches we just overwrite here
             self.repositories[name] = Repository(name, url, signed, persist,
                                                  sslverify, distribution, components,
-                                                 keyserver, key, trusted, arch)
+                                                 keyserver, key, trusted, arch, source)
 
     def _add_isoextras(self, extraspath, element_type):
         """

--- a/oz/Ubuntu.py
+++ b/oz/Ubuntu.py
@@ -444,7 +444,7 @@ echo -n "!$ADDR,%s!" > /dev/ttyS1
         Method to generate and upload custom repository files based on the TDL.
         """
 
-        def build_repo(uri, distribution, components=['main'], trusted=False, arch=None):
+        def build_repo(uri, distribution, components=['main'], trusted=False, arch=None, source=False):
             """
             Builds a Ubuntu / Debian repo string to put into /etc/apt/sources.list.d
 
@@ -467,7 +467,11 @@ echo -n "!$ADDR,%s!" > /dev/ttyS1
                 components = components.split(' ')
 
             info = ' '.join([options, uri, distribution, ' '.join(components)])
-            repo = ''.join(['deb', info, "\n", 'deb-src', info, "\n"])
+            repo_chunks = ['deb', info, "\n"]
+            if source:
+                repo_chunks.append(['deb-src', info, "\n"])
+
+            repo = ''.join(repo_chunks)
             return repo
 
         def setup_key_from_server(server, key):
@@ -562,7 +566,8 @@ echo -n "!$ADDR,%s!" > /dev/ttyS1
                     components = ['main'] if not repo.components else repo.components
                     trusted = False if not repo.trusted else True
                     arch = None if not repo.arch else repo.arch
-                    built_repo = build_repo(uri, distribution, components, trusted, arch)
+                    source = False if not repo.source else True
+                    built_repo = build_repo(uri, distribution, components, trusted, arch, source)
                     handle.write(built_repo)
 
                 try:

--- a/oz/Ubuntu.py
+++ b/oz/Ubuntu.py
@@ -533,7 +533,7 @@ echo -n "!$ADDR,%s!" > /dev/ttyS1
 
                 # Save config file locally and build it, then upload to guest
                 # alphanumeric, hypen, dot and underscore allowed.
-                filename = re.sub(r'([^\.\-\_\w]|_)+', '', repo.name.replace(" ", "_")) + ".list"
+                filename = re.sub(r'([^\.\-\_\w])+', '', repo.name.replace(" ", "_")) + ".list"
                 localname = os.path.join(self.icicle_tmp, filename)
                 with open(localname, 'w') as handle:
                     # Get fragments from URL

--- a/oz/tdl.rng
+++ b/oz/tdl.rng
@@ -203,6 +203,36 @@
                       <ref name='bool'/>
                     </element>
                   </optional>
+                  <optional>
+                    <element name='distribution'>
+                      <text/>
+                    </element>
+                  </optional>
+                  <optional>
+                    <element name='components'>
+                      <text/>
+                    </element>
+                  </optional>
+                  <optional>
+                    <element name='trusted'>
+                      <ref name='bool'/>
+                    </element>
+                  </optional>
+                  <optional>
+                    <element name='arch'>
+                      <text/>
+                    </element>
+                  </optional>
+                  <optional>
+                    <interleave>
+                      <element name='keyserver'>
+                        <text/>
+                      </element>
+                      <element name='key'>
+                        <text/>
+                      </element>
+                    </interleave>
+                  </optional>
                 </interleave>
               </element>
             </zeroOrMore>

--- a/oz/tdl.rng
+++ b/oz/tdl.rng
@@ -219,6 +219,11 @@
                     </element>
                   </optional>
                   <optional>
+                    <element name='source'>
+                      <ref name='bool'/>
+                    </element>
+                  </optional>
+                  <optional>
                     <element name='arch'>
                       <text/>
                     </element>

--- a/oz/tdl.rng
+++ b/oz/tdl.rng
@@ -224,14 +224,14 @@
                     </element>
                   </optional>
                   <optional>
-                    <interleave>
-                      <element name='keyserver'>
-                        <text/>
-                      </element>
-                      <element name='key'>
-                        <text/>
-                      </element>
-                    </interleave>
+                    <element name='keyserver'>
+                      <text/>
+                    </element>
+                  </optional>
+                  <optional>
+                    <element name='key'>
+                      <text/>
+                    </element>
                   </optional>
                 </interleave>
               </element>


### PR DESCRIPTION
The driving factor behind these changes is to add flexibility to the TDL format for apt (like yum has) and ensure that we are writing out to `sources.list.d` instead of only using `add-apt-repository`. `add-apt-repository` will write everything except PPAs and cloud-archive's to sources.list; those 2 get written to `sources.list.d` directory. `cloud-init` has an option to inject (and thus overwrite) all default mirrors in `/etc/apt/sources.list`.

This causes any additional repos oz adds to get blown away.
