### PR TITLE
Trigger a Travis test build on PRs / Commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+language: python
+
+python:
+#  - "3.3"
+#  - "3.2"
+  - "2.7"
+
+before_install:
+  - sudo add-apt-repository -y ppa:pdffs/precise-virt
+  - sudo apt-get update
+  - sudo apt-get install -qq genisoimage libvirt-dev mtools openssh-client python-dev python-guestfs swig libssl1.0.0 python-m2crypto python-libvirt
+
+# Travis uses an isolated virtualenv (see http://about.travis-ci.org/docs/user/languages/python/#Travis-CI-Uses-Isolated-virtualenvs)
+# Install the system python packages to get their deps and then install the pip version to have them locally
+install:
+  - pip install -r requirements.txt              
+  - sudo cp /usr/lib/python2.7/dist-packages/*guestfs* $VIRTUAL_ENV/lib/python$TRAVIS_PYTHON_VERSION/site-packages/
+  - python setup.py install
+  - pip install coverage
+  - pip install coveralls
+  - py.test --genscript=runtests.py
+
+env:
+  - TESTFOLDER=tdl
+  - TESTFOLDER=guest
+  - TESTFOLDER=ozutil
+  - TESTFOLDER=factory
+
+script: 
+  - coverage run -p --source=oz runtests.py --verbose --tb=short tests/$TESTFOLDER
+
+after_success:
+  - coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+pycurl
+# m2crypt has some sslv2 issues (see https://bugzilla.osafoundation.org/show_bug.cgi?id=13024)
+# Use a pip source that patches up like all the OS packages
+-e git://github.com/eventbrite/m2crypto.git@0.21.1-sane#egg=m2crypto
+libvirt-python
+lxml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 pycurl
-# m2crypt has some sslv2 issues (see https://bugzilla.osafoundation.org/show_bug.cgi?id=13024)
-# Use a pip source that patches up like all the OS packages
--e git://github.com/eventbrite/m2crypto.git@0.21.1-sane#egg=m2crypto
+m2crypto
 libvirt-python
 lxml


### PR DESCRIPTION
Adds support for Travis, runs tests on PR / commits. Currently only testing Python 2.7 as we have a few problems with Python 3 (#131 fixes a big problem there). Excluded Python 2.6 intentionally (see #125)

In Travis a test is ran inside a virtualenv that does not pull in global side packages so I had to make a very nasty hack to copy `guestfs` python bindings into the container.  None of those are installable via pip which causes some headache.

I am making Travis run each test directory as it's own "suite" to get parallel testing going and faster results.

An example of a passing build: https://travis-ci.org/helgi/oz/builds/13278492

Additionally using coveralls.io for code coverage reporting. To get the coverage reported then this repo needs to be enabled on coveralls.io - Currently coveralls.io doesn't seem to like combining the results correctly for the overall run since each test "suite" is being ran in parallel, I have a ticket open about that at https://github.com/lemurheavy/coveralls-public/issues/156

If it is ran as a single longer build then the main coverage report shows up properly

The `/bin/true` to `/bin/ls` was a change to appease the ozutil test run on OS X 
