### PR TITLE
use os.path.expanduser on any path configuration in case user configuration contains ~/foo

### DIFF
--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -139,23 +139,27 @@ class Guest(object):
             self.macaddr = macaddress
 
         # configuration from 'paths' section
-        self.output_dir = oz.ozutil.config_get_key(config, 'paths',
-                                                   'output_dir',
-                                                   oz.ozutil.default_output_dir())
+        self.output_dir = os.path.expanduser(
+            oz.ozutil.config_get_key(config, 'paths',
+                                     'output_dir',
+                                     oz.ozutil.default_output_dir()))
 
         oz.ozutil.mkdir_p(self.output_dir)
 
-        self.data_dir = oz.ozutil.config_get_key(config, 'paths',
-                                                 'data_dir',
-                                                 oz.ozutil.default_data_dir())
+        self.data_dir = os.path.expanduser(
+            oz.ozutil.config_get_key(config, 'paths',
+                                     'data_dir',
+                                    oz.ozutil.default_data_dir()))
 
-        self.screenshot_dir = oz.ozutil.config_get_key(config, 'paths',
-                                                       'screenshot_dir',
-                                                       oz.ozutil.default_screenshot_dir(self.data_dir))
+        self.screenshot_dir = os.path.expanduser(
+            oz.ozutil.config_get_key(config, 'paths',
+                                     'screenshot_dir',
+                                     oz.ozutil.default_screenshot_dir(self.data_dir)))
 
-        self.sshprivkey = oz.ozutil.config_get_key(config, 'paths',
-                                                   'sshprivkey',
-                                                   oz.ozutil.default_sshprivkey())
+        self.sshprivkey = os.path.expanduser(
+            oz.ozutil.config_get_key(config, 'paths',
+                                     'sshprivkey',
+                                     oz.ozutil.default_sshprivkey()))
 
         # configuration from 'libvirt' section
         self.libvirt_uri = oz.ozutil.config_get_key(config, 'libvirt', 'uri',


### PR DESCRIPTION
All the `oz.ozutils` default path functions use `expanduser` but that's never ran against user provided configuration.

This change will allow me to use `~/oz` or similar in the config without problem for the paths part of the config.
