### PR TITLE
skip failed guestfs-os-inspect mounts and try to continue

### DIFF
--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -1053,8 +1053,20 @@ class Guest(object):
                     return -1
             mps.sort(_compare)
             for mp_dev in mps:
-                g.mount_options('', mp_dev[1], mp_dev[0])
-
+                try:
+                    g.mount_options('', mp_dev[1], mp_dev[0])
+                except:
+                    if mp_dev[0] == '/':
+                        # If we cannot mount root, we may as well give up
+                        raise
+                    else:
+                        # some custom guests may have fstab content with
+                        # "nofail" as a mount option.  For example, images
+                        # built for EC2 with ephemeral mappings.  These
+                        # fail at this point.  Allow things to continue.
+                        # Profound failures will trigger later on during
+                        # the process.
+                        self.log.warning("Unable to mount (%s) on (%s) - trying to continue" % (mp_dev[1], mp_dev[0]) )
         return g
 
     def _guestfs_remove_if_exists(self, g_handle, path):


### PR DESCRIPTION
Some custom guests may have fstab content with "nofail" as a mount
option.  For example, images built for EC2 with ephemeral mappings.
The guestfs inspection code reports these mounts and they fail if
we try to mount them during normal Oz operations like ICICLE
generation.  This patch allows things to continue.  Profound issues
in the output image should trigger errors later during the process.
