### PR TITLE
make F19 JEOS kickstart work for both iso and url methods

### DIFF
--- a/oz/Fedora.py
+++ b/oz/Fedora.py
@@ -98,7 +98,11 @@ def get_class(tdl, config, auto, output_disk=None, netdev=None, diskbus=None,
             netdev = 'virtio'
         if diskbus is None:
             diskbus = 'virtio'
-        return FedoraGuest(tdl, config, auto, netdev, True, diskbus, True,
+        if tdl.update in [ "19" ]:
+            brokenisomethod = False
+        else:
+            brokenisomethod = True
+        return FedoraGuest(tdl, config, auto, netdev, True, diskbus, brokenisomethod,
                            output_disk, macaddress)
     if tdl.update in ["7", "8", "9"]:
         return FedoraGuest(tdl, config, auto, netdev, False, diskbus, False,

--- a/oz/auto/Fedora19.auto
+++ b/oz/auto/Fedora19.auto
@@ -2,8 +2,6 @@ text
 
 auth --enableshadow --passalgo=sha512
 
-# Use CDROM installation media
-cdrom
 # Run the Setup Agent on first boot
 ignoredisk --only-use=vda
 # Keyboard layouts


### PR DESCRIPTION
This addresses the following issue:

https://github.com/clalancette/oz/issues/149

It allows us to remove the explicit "cdrom" line from the JEOS kickstart for F19 (which breaks url installs for me), while still having ISO based installs work.  I have tested this successfully.

It works by adding back in the explicit "method=" line when generating the isolinux.cfg file.  For the moment, I've had this apply only to F19.

As an aside, it would be interesting to figure out when the "brokenisomethod" got fixed, and if it is likely to remain fixed.  At the moment the class factory assume brokenness for version >= 10.
