### PR TITLE
update brokeniso usage - revert F19 and F20 kickstart files

### DIFF
--- a/oz/Fedora.py
+++ b/oz/Fedora.py
@@ -98,7 +98,7 @@ def get_class(tdl, config, auto, output_disk=None, netdev=None, diskbus=None,
             netdev = 'virtio'
         if diskbus is None:
             diskbus = 'virtio'
-        if tdl.update in [ "19" ]:
+        if tdl.update in [ "18", "19", "20" ]:
             brokenisomethod = False
         else:
             brokenisomethod = True

--- a/oz/auto/Fedora19.auto
+++ b/oz/auto/Fedora19.auto
@@ -1,27 +1,24 @@
+install
 text
-
-auth --enableshadow --passalgo=sha512
-
-# Run the Setup Agent on first boot
-ignoredisk --only-use=vda
-# Keyboard layouts
-keyboard --vckeymap=us --xlayouts='us'
-# System language
+keyboard us
 lang en_US.UTF-8
-
-# Network information
-network --bootproto=dhcp --device=eth0 --ipv6=auto --activate
-network --hostname=localhost.localdomain
-# Root password
+skipx
+network --device eth0 --bootproto dhcp
 rootpw %ROOTPW%
-# System timezone
-timezone America/New_York --isUtc
-# System bootloader configuration
-bootloader --location=mbr --boot-drive=vda
-autopart --type=lvm
-# Partition clearing information
-clearpart --none --initlabel
+firewall --disabled
+authconfig --enableshadow --enablemd5
+selinux --enforcing
+timezone --utc America/New_York
+bootloader --location=mbr --append="console=tty0 console=ttyS0,115200"
+zerombr
+clearpart --all --drives=vda
 
+part biosboot --fstype=biosboot --size=1
+part /boot --fstype ext4 --size=200 --ondisk=vda
+part pv.2 --size=1 --grow --ondisk=vda
+volgroup VolGroup00 --pesize=32768 pv.2
+logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=768 --grow --maxsize=1536
+logvol / --fstype ext4 --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow
 reboot
 
 %packages

--- a/oz/auto/Fedora20.auto
+++ b/oz/auto/Fedora20.auto
@@ -1,29 +1,24 @@
+install
 text
-
-auth --enableshadow --passalgo=sha512
-
-# Use CDROM installation media
-cdrom
-# Run the Setup Agent on first boot
-ignoredisk --only-use=vda
-# Keyboard layouts
-keyboard --vckeymap=us --xlayouts='us'
-# System language
+keyboard us
 lang en_US.UTF-8
-
-# Network information
-network --bootproto=dhcp --device=eth0 --ipv6=auto --activate
-network --hostname=localhost.localdomain
-# Root password
+skipx
+network --device eth0 --bootproto dhcp
 rootpw %ROOTPW%
-# System timezone
-timezone America/New_York --isUtc
-# System bootloader configuration
-bootloader --location=mbr --boot-drive=vda
-autopart --type=lvm
-# Partition clearing information
-clearpart --none --initlabel
+firewall --disabled
+authconfig --enableshadow --enablemd5
+selinux --enforcing
+timezone --utc America/New_York
+bootloader --location=mbr --append="console=tty0 console=ttyS0,115200"
+zerombr
+clearpart --all --drives=vda
 
+part biosboot --fstype=biosboot --size=1
+part /boot --fstype ext4 --size=200 --ondisk=vda
+part pv.2 --size=1 --grow --ondisk=vda
+volgroup VolGroup00 --pesize=32768 pv.2
+logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=768 --grow --maxsize=1536
+logvol / --fstype ext4 --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow
 reboot
 
 %packages


### PR DESCRIPTION
The iso command line issue seems to have been resolved between F17 and F18.

Further testing indicates that the improper use of the brokeniso flag
is the actual root cause of the issues with the original F19 JEOS ks
file.

With the flag set correctly we can now use the same kickstart file for
F18, F19 and F20.
