### PR TITLE
use explicit repo=cdrom command line option - revert to F18/19/20 kickst...

### DIFF
--- a/oz/RHEL_7.py
+++ b/oz/RHEL_7.py
@@ -45,7 +45,11 @@ class RHEL7Guest(oz.RedHat.RedHatLinuxCDYumGuest):
         if self.tdl.installtype == "url":
             initrdline += " repo=" + self.url + "\n"
         else:
-            initrdline += "\n"
+            # RHEL6 dropped this command line directive due to an Anaconda bug that
+            # has since been fixed.
+            # Note that this used to be "method=" but that has been depricated for some
+            # time.
+            initrdline += " repo=cdrom:/dev/cdrom"
         self._modify_isolinux(initrdline)
 
     def get_auto_path(self):

--- a/oz/auto/RHEL7.auto
+++ b/oz/auto/RHEL7.auto
@@ -1,37 +1,27 @@
+install
 text
-
-auth --enableshadow --passalgo=sha512
-
-# Use CDROM installation media
-cdrom
-# Run the Setup Agent on first boot
-ignoredisk --only-use=vda
-# Keyboard layouts
-keyboard --vckeymap=us --xlayouts='us'
-# System language
+keyboard us
 lang en_US.UTF-8
-
-# Network information
+skipx
 network --device eth0 --bootproto dhcp
-# Root password
 rootpw %ROOTPW%
-# System timezone
-timezone America/New_York --isUtc
-# System bootloader configuration
-bootloader --location=mbr --boot-drive=vda
-autopart --type=lvm
-# Partition clearing information
-clearpart --none --initlabel
+firewall --disabled
+authconfig --enableshadow --enablemd5
+selinux --enforcing
+timezone --utc America/New_York
+bootloader --location=mbr --append="console=tty0 console=ttyS0,115200"
+zerombr
+clearpart --all --drives=vda
 
+part biosboot --fstype=biosboot --size=1
+part /boot --fstype ext4 --size=200 --ondisk=vda
+part pv.2 --size=1 --grow --ondisk=vda
+volgroup VolGroup00 --pesize=32768 pv.2
+logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=768 --grow --maxsize=1536
+logvol / --fstype ext4 --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow
 reboot
 
 %packages
 @core
 
-%end
-
-%post
-# Without this the NetworkManager announce script fires too early and gives a blank IP
-# Once this is fixed the sed below will become a NOOP
-sed -i '/Before=network\.target$/c\Before=network\.target network\.service' /usr/lib/systemd/system/NetworkManager.service
 %end


### PR DESCRIPTION
...art for RHEL7

This follows on from the discovery that the "brokeniso" bug was fixed in the F18
timeframe.  The kernel command line option allows us to use the same kickstart for
RHEL7, and F18-F20.
