### PR TITLE
restore logic to force qcow2 image type when creating disk image with a ...

### DIFF
--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -517,7 +517,11 @@ class Guest(object):
         self.lxml_subelement(vol, "name", filename)
         self.lxml_subelement(vol, "allocation", "0")
         target = self.lxml_subelement(vol, "target")
-        self.lxml_subelement(target, "format", None, {"type":self.image_type})
+        if backing_filename:
+            # Only qcow2 supports image creation using a backing file
+            self.lxml_subelement(target, "format", None, {"type":"qcow2"})
+        else:
+            self.lxml_subelement(target, "format", None, {"type":self.image_type})
         # FIXME: this makes the permissions insecure, but is needed since
         # libvirt launches guests as qemu:qemu
         permissions = self.lxml_subelement(target, "permissions")


### PR DESCRIPTION
...backing store

This was in the original version of the backing_store feature but seems to
have gotten lost in one of the refactors during the 0.12 cycle.  This simply
restores the old behavior.  Interestingly, without this libvirt will still
create the new disk image but it seems to contain invalid data.
