### PR TITLE
Add ability to log detailed Fedora debug messages via a virtio console

### DIFF
--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -43,6 +43,7 @@ import base64
 import hashlib
 import errno
 import re
+import StringIO
 
 import oz.ozutil
 import oz.OzException
@@ -216,7 +217,7 @@ class Guest(object):
 
         self.icicle_tmp = os.path.join(self.data_dir, "icicletmp",
                                        self.tdl.name)
-        self.listen_port = random.randrange(1024, 65535)
+        self.listen_domain_socket = os.path.join("/tmp","oz-listenter-%s" % (self.uuid))
 
         self.connect_to_libvirt()
 
@@ -265,7 +266,7 @@ class Guest(object):
         self.log.debug("update: %s, arch: %s, diskimage: %s" % (self.tdl.update, self.tdl.arch, self.diskimage))
         self.log.debug("nicmodel: %s, clockoffset: %s" % (self.nicmodel, self.clockoffset))
         self.log.debug("mousetype: %s, disk_bus: %s, disk_dev: %s" % (self.mousetype, self.disk_bus, self.disk_dev))
-        self.log.debug("icicletmp: %s, listen_port: %d" % (self.icicle_tmp, self.listen_port))
+        self.log.debug("icicletmp: %s, listen_domain_socket: %s" % (self.icicle_tmp, self.listen_domain_socket))
 
     def image_name(self):
         """
@@ -394,13 +395,15 @@ class Guest(object):
                 tmp.set(k, v)
         return tmp
 
-    def _generate_serial_xml(self, devices):
+    def _generate_serial_xml(self, devices, install_stage):
         """
         Method to generate the serial portion of the libvirt XML.
+        install_stage: True if generating for initial install, False otherwise
+                       Ignored here, used in sub-classes
         """
-        serial = self.lxml_subelement(devices, "serial", None, {'type':'tcp'})
+        serial = self.lxml_subelement(devices, "serial", None, {'type':'unix'})
         self.lxml_subelement(serial, "source", None,
-                             {'mode':'bind', 'host':'127.0.0.1', 'service':str(self.listen_port)})
+                             {'mode':'bind', 'path':self.listen_domain_socket})
         self.lxml_subelement(serial, "protocol", None, {'type':'raw'})
         self.lxml_subelement(serial, "target", None, {'port':'1'})
 
@@ -464,7 +467,7 @@ class Guest(object):
         console = self.lxml_subelement(devices, "serial", None, {'type':'pty'})
         self.lxml_subelement(console, "target", None, {'port':'0'})
         # serial
-        self._generate_serial_xml(devices)
+        self._generate_serial_xml(devices, True)
         # boot disk
         bootDisk = self.lxml_subelement(devices, "disk", None, {'device':'disk', 'type':'file'})
         self.lxml_subelement(bootDisk, "target", None, {'dev':self.disk_dev, 'bus':self.disk_bus})
@@ -714,7 +717,7 @@ class Guest(object):
                 raise oz.OzException.OzException("Unknown libvirt error")
 
     def _wait_for_install_finish(self, libvirt_dom, count,
-                                 inactivity_timeout=300):
+                                 inactivity_timeout=1000):
         """
         Method to wait for an installation to finish.  This will wait around
         until either the VM has gone away (at which point it is assumed the
@@ -729,9 +732,39 @@ class Guest(object):
         inactivity_countdown = inactivity_timeout
         origcount = count
         saved_exception = None
+
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.settimeout(1)
+        sock.connect(self.listen_domain_socket)
+        data = StringIO.StringIO()
+
         while count > 0 and inactivity_countdown > 0:
             if count % 10 == 0:
                 self.log.debug("Waiting for %s to finish installing, %d/%d" % (self.tdl.name, count, origcount))
+            do_sleep = True
+            try:
+                # Save most recently logged location in string
+                origpos=data.tell()
+                # Now seek to end to write new content
+                data.seek(0,2)
+                data.write(sock.recv(10000))
+                # If we wrote successfully, return to original log point
+                data.seek(origpos)
+            except socket.timeout:
+                # the socket times out after 1 second.  We can just fall
+                # through to the below code because it is a noop, *except* that
+                # we don't want to sleep.  Set the flag
+                do_sleep = False
+
+	    for line in data:
+		if line[-1] != '\n':
+		    # This is an incomplete line - don't print it yet - move the pointer back
+		    # and allow it to print out on the next time around
+		    data.seek(0-len(line),2)
+		    break
+		else:
+		    self.log.debug(line.rstrip())
+
             try:
                 total_disk_req, total_net_bytes = self._get_disk_and_net_activity(libvirt_dom, disks, interfaces)
             except libvirt.libvirtError as e:
@@ -766,7 +799,14 @@ class Guest(object):
             last_disk_activity = total_disk_req
             last_network_activity = total_net_bytes
             count -= 1
-            time.sleep(1)
+            if do_sleep:
+                time.sleep(1)
+
+        try:
+            sock.close()
+            os.unlink(self.listen_domain_socket)
+        except:
+            pass
 
         # We get here because of a libvirt exception, an absolute timeout, or
         # an I/O timeout; we sort this out below
@@ -1126,6 +1166,7 @@ class Guest(object):
         Internal method to take input libvirt XML (which may have been provided
         by the user) and add an appropriate serial section so that guest
         announcement works properly.
+        NOTE: Using this function implies that we are doing a customize, not an initial install
         """
         input_doc = lxml.etree.fromstring(libvirt_xml)
         serialNode = input_doc.xpath("/domain/devices/serial")
@@ -1150,7 +1191,8 @@ class Guest(object):
         elif devlen > 1:
             raise oz.OzException.OzException("%d devices sections specified, something is wrong with the libvirt XML" % (devlen))
 
-        self._generate_serial_xml(devices[0])
+        # We pass False to let the generator know we are customizing, not doing an install
+        self._generate_serial_xml(devices[0], False)
 
         xml = lxml.etree.tostring(input_doc, pretty_print=True)
         self.log.debug("Generated XML:\n%s" % (xml))
@@ -1196,11 +1238,11 @@ class Guest(object):
         """
         self.log.info("Waiting for guest %s to boot" % (self.tdl.name))
 
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 
         try:
             sock.settimeout(1)
-            sock.connect(('127.0.0.1', self.listen_port))
+            sock.connect(self.listen_domain_socket)
 
             addr = None
             count = 300
@@ -1252,6 +1294,7 @@ class Guest(object):
                 count -= 1
         finally:
             sock.close()
+            os.unlink(self.listen_domain_socket)
 
         if addr is None:
             raise oz.OzException.OzException("Timed out waiting for guest to boot")


### PR DESCRIPTION
This also changes the serial monitoring socket from a TCP connection to a
domain socket file.  Without this I ran into issues with the listening socket
failing to recreate when doing ICICLE generation due to TCP stack timeout
issues.
