### PR TITLE
add proxy support for RedHat

### DIFF
--- a/oz/RedHat.py
+++ b/oz/RedHat.py
@@ -78,6 +78,8 @@ Subsystem	sftp	/usr/libexec/openssh/sftp-server
                                         self.tdl.distro + self.tdl.update + self.tdl.arch + "-ramdisk")
 
         self.cmdline = "method=" + self.url + " ks=file:/ks.cfg"
+	if self.tdl.proxy:
+		self.cmdline += " proxy=%s" % self.tdl.proxy
 
     def _generate_new_iso(self):
         """

--- a/oz/TDL.py
+++ b/oz/TDL.py
@@ -289,6 +289,7 @@ class TDL(object):
         self.commands = self._parse_commands()
 
         self.disksize = self._parse_disksize()
+        self.proxy = _xml_get_value(self.doc, '/template/proxy', 'proxy')
 
         self.icicle_extra_cmd = _xml_get_value(self.doc,
                                                '/template/os/icicle/extra_command',

--- a/oz/tdl.rng
+++ b/oz/tdl.rng
@@ -188,6 +188,9 @@
               <ref name='disk_size'/>
             </element>
           </element>
+          <element name='proxy'>
+              <ref name='proxy'/>
+          </element>
         </optional>
       </interleave>
     </element>
@@ -295,6 +298,11 @@
   <define name='disk_size'>
     <data type="string">
       <param name="pattern">([0-9]*) *([GT]?)</param>
+    </data>
+  </define>
+
+  <define name='proxy'>
+    <data type="string">
     </data>
   </define>
 


### PR DESCRIPTION
When install CentOS 7 required external access to *.fedoraproject.org.
If someone behind proxy enviroment, It block for a longtime..

This patch.. add proxy element to tdl, and add proxy settings to initrd.

```
<template>
   <name>oz-centos7</name>
   <description>CentOS 7 x86_64 template</description>
   <proxy>http://proxy.yourcompany.com:8088</proxy>
   <os>
      <name>CentOS-7</name>
      <version>7</version>
      <arch>x86_64</arch>
   </os>
</template>
```
