### PR TITLE
Modification to MANIFEST.in to fix rpm builds

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-include README COPYING examples/*.tdl man/*.1 oz.cfg docs/*.rng Makefile
+include README COPYING examples/*.tdl man/*.1 oz.cfg docs/*.rng oz/*.rng Makefile
 include man/examples/*.example man/examples/header man/examples/footer
 include oz/auto/*


### PR DESCRIPTION
Include oz/*.rng files in MANIFEST.in, so they are included when
executing make rpm or make srpm
