### PR TITLE
Update copyright to pass Lintian test

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -6,7 +6,7 @@ It was downloaded from:
 
     http://aeolusproject.org/oz.html
 
-Upstream Author(s):
+Upstream Author:
 
     Chris Lalancette <clalance@redhat.com>
 


### PR DESCRIPTION
Hey there,

This (very small) PR fixes a minor issue with the copyright file that causes a Lintian test to fail on Debian, and therefore the build to abort.

More details are in the commit message (for the commit that I'm proposing in this PR)

Cheers, 
