### PR TITLE
Adding support for version 1 for RHEL 7, so RHEL-7.1 and CentOS-7.1 are allowed.

### DIFF
--- a/oz/RHEL_7.py
+++ b/oz/RHEL_7.py
@@ -74,4 +74,4 @@ def get_supported_string():
     """
     Return supported versions as a string.
     """
-    return "RHEL 7: Beta, 0"
+    return "RHEL 7: Beta, 0, 1"


### PR DESCRIPTION
Updating RHEL_7.py supported versions to be "Base, 0, 1"

