### PR TITLE
i686 arch admitted as valid architecture for TDL files

### DIFF
--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -124,7 +124,7 @@ class Guest(object):
         # for backwards compatibility
         self.name = self.tdl.name
 
-        if not self.tdl.arch in [ "i386", "x86_64", "ppc64", "ppc64le", "aarch64", "armv7l" ]:
+        if not self.tdl.arch in [ "i386", "i686", "x86_64", "ppc64", "ppc64le", "aarch64", "armv7l" ]:
             raise oz.OzException.OzException("Unsupported guest arch " + self.tdl.arch)
 
         if os.uname()[4] in ["i386", "i586", "i686"] and self.tdl.arch == "x86_64":

--- a/oz/TDL.py
+++ b/oz/TDL.py
@@ -205,7 +205,7 @@ class TDL(object):
 
         self.arch = _xml_get_value(self.doc, '/template/os/arch',
                                    'OS architecture')
-        if self.arch not in [ "i386", "x86_64", "ppc64", "ppc64le", "aarch64", "armv7l" ]:
+        if self.arch not in [ "i386", "i686", "x86_64", "ppc64", "ppc64le", "aarch64", "armv7l" ]:
             raise oz.OzException.OzException("Architecture must be one of 'i386, x86_64, ppc64, ppc64le, armv7l, or aarch64'")
 
         self.key = _xml_get_value(self.doc, '/template/os/key', 'OS key',

--- a/oz/tdl.rng
+++ b/oz/tdl.rng
@@ -29,6 +29,7 @@
             <element name='arch'>
               <choice>
                 <value>i386</value>
+                <value>i686</value>
                 <value>x86_64</value>
                 <value>ppc64</value>
                 <value>ppc64le</value>


### PR DESCRIPTION
Patch for issue 194