### PR TITLE
Changed RHEL_6.py to list .6 and .7 as supported.

### DIFF
--- a/oz/RHEL_6.py
+++ b/oz/RHEL_6.py
@@ -71,4 +71,4 @@ def get_supported_string():
     """
     Return supported versions as a string.
     """
-    return "RHEL/OL/CentOS/Scientific Linux{,CERN} 6: 0, 1, 2, 3, 4, 5"
+    return "RHEL/OL/CentOS/Scientific Linux{,CERN} 6: 0, 1, 2, 3, 4, 5, 6, 7"


### PR DESCRIPTION
We use oz for building Centos 6.6 and 6.7 images. Now that we are supporting both, the 5 limit is becoming a pain. 