### PR TITLE
Make sure only the Oz's ssh privkey is used

### DIFF
--- a/oz/Linux.py
+++ b/oz/Linux.py
@@ -99,6 +99,7 @@ class LinuxCDGuest(oz.Guest.CDGuest):
                                                   "-o", "ConnectTimeout=" + str(timeout),
                                                   "-o", "UserKnownHostsFile=/dev/null",
                                                   "-o", "PasswordAuthentication=no",
+                                                  "-o", "IdentitiesOnly yes",
                                                   "root@" + guestaddr, command],
                                                  printfn=self.log.debug)
 
@@ -126,6 +127,7 @@ class LinuxCDGuest(oz.Guest.CDGuest):
                                                   "-o", "ConnectTimeout=" + str(timeout),
                                                   "-o", "UserKnownHostsFile=/dev/null",
                                                   "-o", "PasswordAuthentication=no",
+                                                  "-o", "IdentitiesOnly yes",
                                                   file_to_upload,
                                                   "root@" + guestaddr + ":" + destination],
                                                  printfn=self.log.debug)


### PR DESCRIPTION
This makes sure, that only the key provided by the ssh's `-i` option is
used. This prevents the ssh's `"Too many authentication failures"` error,
when the user has multiple ssh private keys.