### PR TITLE
make all timeouts configurable

### DIFF
--- a/oz.cfg
+++ b/oz.cfg
@@ -19,3 +19,9 @@ jeos = no
 
 [icicle]
 safe_generation = no
+
+[timeouts]
+install = 1200
+inactivity = 300
+boot = 300
+shutdown = 90


### PR DESCRIPTION
I have, at various times, found it useful to override all of these values by hand patching the code. I know of at least one circumstance where they were overridden in Fedora koji in the same way.  This preserves the existing values while allowing them to be tweaked as normal configuration variables.