### PR TITLE
UEFI firmware for aarch64

### DIFF
--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -471,6 +471,12 @@ class Guest(object):
             if self.tdl.arch == "armv7l":
                 cmdline += " console=ttyAMA0"
             self.lxml_subelement(osNode, "cmdline", cmdline)
+        # This is a hardcoded hack but it does work with the most recent externally available firmware
+        # TODO: A more elegant heuristic similar to libguestfs as detailed here:
+        # http://blog.wikichoon.com/2016/01/uefi-support-in-virt-install-and-virt.html
+        if self.tdl.arch == "aarch64":
+            self.lxml_subelement(osNode, "loader", "/usr/share/edk2.git/aarch64/QEMU_EFI-pflash.raw", { 'readonly': 'yes', 'type': 'pflash' })
+            self.lxml_subelement(osNode, "nvram", None, {'template':'/usr/share/edk2.git/aarch64/vars-template-pflash.raw'})
         # poweroff, reboot, crash
         self.lxml_subelement(domain, "on_poweroff", "destroy")
         self.lxml_subelement(domain, "on_reboot", "destroy")


### PR DESCRIPTION
Without this, Anaconda installs fail when doing hardware detection.
This is not going to be fixed.  If we want Oz to work for Anaconda
based installs on aarch64 we need to use UEFI firmware.  This is a
starter patch.  I'm sure it can be improved.