### PR TITLE
Replace the use of rm_f() with rm()

### DIFF
--- a/oz/Mageia.py
+++ b/oz/Mageia.py
@@ -199,13 +199,13 @@ label customiso
         # Remove any lease files; this is so that subsequent boots don't try
         # to connect to a DHCP server that is on a totally different network
         for lease in g_handle.glob_expand("/var/lib/dhcp/*.leases"):
-            g_handle.rm_f(lease)
+            g_handle.rm(lease)
 
         for lease in g_handle.glob_expand("/var/lib/dhcp6/*.leases"):
-            g_handle.rm_f(lease)
+            g_handle.rm(lease)
 
         for lease in g_handle.glob_expand("/var/lib/dhcp6/*.lease"):
-            g_handle.rm_f(lease)
+            g_handle.rm(lease)
 
     def _collect_teardown(self, libvirt_xml):
         """

--- a/oz/OpenSUSE.py
+++ b/oz/OpenSUSE.py
@@ -191,13 +191,13 @@ class OpenSUSEGuest(oz.Linux.LinuxCDGuest):
         # Remove any lease files; this is so that subsequent boots don't try
         # to connect to a DHCP server that is on a totally different network
         for lease in g_handle.glob_expand("/var/lib/dhcp/*.leases"):
-            g_handle.rm_f(lease)
+            g_handle.rm(lease)
 
         for lease in g_handle.glob_expand("/var/lib/dhcp6/*.leases"):
-            g_handle.rm_f(lease)
+            g_handle.rm(lease)
 
         for lease in g_handle.glob_expand("/var/lib/dhcp6/*.lease"):
-            g_handle.rm_f(lease)
+            g_handle.rm(lease)
 
     def _collect_teardown(self, libvirt_xml):
         """

--- a/oz/RedHat.py
+++ b/oz/RedHat.py
@@ -244,10 +244,10 @@ label customiso
         # Remove any lease files; this is so that subsequent boots don't try
         # to connect to a DHCP server that is on a totally different network
         for lease in g_handle.glob_expand("/var/lib/dhclient/*.leases"):
-            g_handle.rm_f(lease)
+            g_handle.rm(lease)
 
         for lease in g_handle.glob_expand("/var/lib/NetworkManager/*.lease"):
-            g_handle.rm_f(lease)
+            g_handle.rm(lease)
 
     def _collect_teardown(self, libvirt_xml):
         """

--- a/oz/Ubuntu.py
+++ b/oz/Ubuntu.py
@@ -300,7 +300,7 @@ PROMPT 0
         # Remove any lease files; this is so that subsequent boots don't try
         # to connect to a DHCP server that is on a totally different network
         for lease in g_handle.glob_expand("/var/lib/dhcp/*.leases"):
-            g_handle.rm_f(lease)
+            g_handle.rm(lease)
 
     def _image_ssh_setup_step_1(self, g_handle):
         """


### PR DESCRIPTION
This reinstates the ability to build on Centos 6 with the version of libguestfs available.

Fixes clalancette/oz/#215