### PR TITLE
_copy_to_iso(): make sure tar is done before going ahead

### DIFF
--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -1540,9 +1540,14 @@ class CDGuest(Guest):
                             tar.kill()
                             raise
 
-                        # FIXME: we really should check tar.poll() here to get
-                        # the return code, and print out stdout and stderr if
-                        # we fail.  This will make debugging problems easier
+                        # Make sure tar is fully done with the archive before
+                        # we can continue.
+                        tar.wait()
+                        if tar.returncode:
+                            self.log.debug('tar stdout: %s' % stdouttmp.read())
+                            self.log.debug('tar stderr: %s' % stderrtmp.read())
+                            raise oz.OzException.OzException("Tar exited with an error")
+
                     finally:
                         stdouttmp.close()
                         stderrtmp.close()


### PR DESCRIPTION
I was running into a error where recursively_add_write_bit() was failing
with a "Permission Denied" error. It turns out that tar wasn't fully done
extracting the achive and it was changing permissions back to u-r after we
set changed them to u+r (tar will change permissions at the very end, after
files after it has written all files).