### PR TITLE
fix bug of kernelparam losing of ubuntu

### DIFF
--- a/oz/Ubuntu.py
+++ b/oz/Ubuntu.py
@@ -73,7 +73,11 @@ Subsystem       sftp    /usr/libexec/openssh/sftp-server
         self.initrdcache = os.path.join(self.data_dir, "kernels",
                                         self.tdl.distro + self.tdl.update + self.tdl.arch + "-ramdisk")
 
-        self.cmdline = "priority=critical locale=en_US"
+        if tdl.kernel_param:
+            self.cmdline = tdl.kernel_param
+        else:
+            self.cmdline = ""
+        self.cmdline += " priority=critical locale=en_US"
 
         self.reboots = 0
         if self.tdl.update in ["5.04", "5.10"]:


### PR DESCRIPTION
kernelparam defined in tdl file will ignore by oz before, this is the patch to fix it