### PR TITLE
Prevent automatic gzip decompression by unsetting Accept-Encoding

### DIFF
--- a/oz/ozutil.py
+++ b/oz/ozutil.py
@@ -834,7 +834,8 @@ def http_download_file(url, fd, show_progress, logger):
     """
     with requests.Session() as requests_session:
         requests_session.mount('file://', LocalFileAdapter())
-        response = requests_session.get(url, stream=True, allow_redirects=True)
+        response = requests_session.get(url, stream=True, allow_redirects=True,
+                                        headers={'Accept-Encoding': ''})
         file_size = int(response.headers.get('Content-Length'))
         chunk_size = 10*1024*1024
         done = 0


### PR DESCRIPTION
By not setting Accept-Encoding, servers will send Content-Type: x-gzip, which prevents
urllib3 (on behalf of requests) from decompressing it.

Fixes: #237
Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>