### PR TITLE
make vnc accessible from remote

### DIFF
--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -486,7 +486,7 @@ class Guest(object):
         # graphics
         if not self.tdl.arch in ["aarch64", "armv7l"]:
             # qemu for arm/aarch64 does not support a graphical console - amazingly
-            oz.ozutil.lxml_subelement(devices, "graphics", None, {'port':'-1', 'type':'vnc'})
+            oz.ozutil.lxml_subelement(devices, "graphics", None, {'port':'-1', 'type':'vnc', 'listen':'0.0.0.0'})
         # network
         interface = oz.ozutil.lxml_subelement(devices, "interface", None, {'type':'bridge'})
         oz.ozutil.lxml_subelement(interface, "source", None, {'bridge':self.bridge_name})


### PR DESCRIPTION
We create images from a remote server. This patch makes us can access vnc while kickstart stage and found out what's going wrong.