### PR TITLE
Add intial support for s390x (aka z Systems)

### DIFF
--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -419,7 +419,11 @@ class Guest(object):
         oz.ozutil.lxml_subelement(serial, "source", None,
                                   {'mode':'bind', 'host':'127.0.0.1', 'service':str(self.listen_port)})
         oz.ozutil.lxml_subelement(serial, "protocol", None, {'type':'raw'})
-        oz.ozutil.lxml_subelement(serial, "target", None, {'port':'1'})
+        target = oz.ozutil.lxml_subelement(serial, "target", None, {'port':'1'})
+        if self.tdl.arch == 's390x':
+            # use a different console, as sclp can be used as most once
+            target.set('type', 'sclp-serial')
+            oz.ozutil.lxml_subelement(target, "model", None, {'name':'sclplmconsole'})
 
     def _generate_virtio_channel(self, devices, name):
         virtio = oz.ozutil.lxml_subelement(devices, "channel", None, {'type': 'tcp'})

--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -484,8 +484,8 @@ class Guest(object):
         # devices
         devices = oz.ozutil.lxml_subelement(domain, "devices")
         # graphics
-        if not self.tdl.arch in ["aarch64", "armv7l"]:
-            # qemu for arm/aarch64 does not support a graphical console - amazingly
+        if not self.tdl.arch in ["aarch64", "armv7l", "s390x"]:
+            # qemu for arm/aarch64/s390x does not support a graphical console - amazingly
             oz.ozutil.lxml_subelement(devices, "graphics", None, {'port':'-1', 'type':'vnc'})
         # network
         interface = oz.ozutil.lxml_subelement(devices, "interface", None, {'type':'bridge'})

--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -131,7 +131,7 @@ class Guest(object):
         # for backwards compatibility
         self.name = self.tdl.name
 
-        if not self.tdl.arch in ["i386", "x86_64", "ppc64", "ppc64le", "aarch64", "armv7l"]:
+        if not self.tdl.arch in ["i386", "x86_64", "ppc64", "ppc64le", "aarch64", "armv7l", "s390x"]:
             raise oz.OzException.OzException("Unsupported guest arch " + self.tdl.arch)
 
         if os.uname()[4] in ["i386", "i586", "i686"] and self.tdl.arch == "x86_64":

--- a/oz/TDL.py
+++ b/oz/TDL.py
@@ -206,8 +206,8 @@ class TDL(object):
 
         self.arch = _xml_get_value(self.doc, '/template/os/arch',
                                    'OS architecture')
-        if self.arch not in ["i386", "x86_64", "ppc64", "ppc64le", "aarch64", "armv7l"]:
-            raise oz.OzException.OzException("Architecture must be one of 'i386, x86_64, ppc64, ppc64le, armv7l, or aarch64'")
+        if self.arch not in ["i386", "x86_64", "ppc64", "ppc64le", "aarch64", "armv7l", "s390x"]:
+            raise oz.OzException.OzException("Architecture must be one of 'i386, x86_64, ppc64, ppc64le, armv7l, aarch64, or s390x'")
 
         self.key = _xml_get_value(self.doc, '/template/os/key', 'OS key',
                                   optional=True)

--- a/oz/tdl.rng
+++ b/oz/tdl.rng
@@ -34,6 +34,7 @@
                 <value>ppc64le</value>
                 <value>aarch64</value>
                 <value>armv7l</value>
+                <value>s390x</value>
               </choice>
             </element>
             <optional>


### PR DESCRIPTION
This small patch series adds an initial support for the z Systems architecture, aka s390x.

This requires a libvirt version fixed to properly handle `<serial>` for s390x guests; the work went upstream yesterday, and it will be released in a week or so as libvirt 3.10.0.  The online documentation already describes the syntax used:
https://libvirt.org/formatdomain.html#elementCharSerial