### PR TITLE
Boot-related fixes on s390x

### DIFF
--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -1122,7 +1122,7 @@ class Guest(object):
                 try:
                     # note that we have to build the data up here, since there
                     # is no guarantee that we will get the whole write in one go
-                    self.data += self.sock.recv(100)
+                    self.data += self.sock.recv(8192)
                 except socket.timeout:
                     # the socket times out after 1 second.  We can just fall
                     # through to the below code because it is a noop.

--- a/oz/RedHat.py
+++ b/oz/RedHat.py
@@ -335,6 +335,8 @@ label customiso
 
         if self.tdl.arch in ['ppc64', 'ppc64le']:
             announce_device = '/dev/hvc1'
+        elif self.tdl.arch == 's390x':
+            announce_device = '/dev/sclp_line0'
         else:
             announce_device = '/dev/ttyS1'
 


### PR DESCRIPTION
A couple of additional fixes for s390x support -- mostly related to the announce payload at boot.

Followup for: https://github.com/clalancette/oz/pull/245