### PR TITLE
Fix debian repos

### DIFF
--- a/oz/Debian.py
+++ b/oz/Debian.py
@@ -608,6 +608,11 @@ critical initrd=%s/initrd.gz --
             os.unlink(self.kernelfname)
             raise
 
+    def _remove_repos(self, guestaddr):
+        # FIXME: until we switch over to doing repository add by hand (instead
+        # of using add-apt-repository), we can't really reliably implement this
+        pass
+
     def generate_install_media(self, force_download=False,
                                customize_or_icicle=False):
         """

--- a/oz/Debian.py
+++ b/oz/Debian.py
@@ -438,7 +438,7 @@ critical initrd=%s/initrd.gz --
         self.log.debug("Installing additional repository files")
 
         for repo in list(self.tdl.repositories.values()):
-            self.guest_execute_command(guestaddr, "echo '%s' > /etc/apt/sources.list.d/%s" % (repo.url.strip('\'"'), repo.name + "list"))
+            self.guest_execute_command(guestaddr, "echo '%s' > /etc/apt/sources.list.d/%s" % (repo.url.strip('\'"'), repo.name + ".list"))
             self.guest_execute_command(guestaddr, "apt-get update")
 
     def _install_packages(self, guestaddr, packstr):


### PR DESCRIPTION
Debian does not implemented `_remove_repos`, this will raise an error:

```
DEBUG:oz.GuestFSManager:Syncing
DEBUG:oz.GuestFSManager:Unmounting all
Traceback (most recent call last):
  File "/usr/bin/oz-install", line 172, in <module>
    guest.customize(libvirt_xml)
  File "/usr/lib/python2.7/site-packages/oz/Linux.py", line 348, in customize
    return self._internal_customize(libvirt_xml, "mod_only")
  File "/usr/lib/python2.7/site-packages/oz/Linux.py", line 323, in _internal_customize
    self.do_customize(guestaddr)
  File "/usr/lib/python2.7/site-packages/oz/Linux.py", line 248, in do_customize
    self._remove_repos(guestaddr)
  File "/usr/lib/python2.7/site-packages/oz/Linux.py", line 218, in _remove_repos
    raise oz.OzException.OzException("Repository removal not implemented for guest %s" % (self.tdl.distro))
oz.OzException.OzException: Repository removal not implemented for guest Debian
```

Also, reposities filename are end with `.list`.