### PR TITLE
RHEL 7 supports anaconda log channel

### DIFF
--- a/oz/RHEL_7.py
+++ b/oz/RHEL_7.py
@@ -35,6 +35,7 @@ class RHEL7Guest(oz.RedHat.RedHatLinuxCDYumGuest):
                                                  output_disk, netdev, diskbus,
                                                  True, True, "cpio", macaddress,
                                                  True)
+        self.virtio_channel_name = 'org.fedoraproject.anaconda.log.0'
 
     def _modify_iso(self):
         """


### PR DESCRIPTION
virtio debug channel works in RHEL7, so we can benefit from it