### PR TITLE
Apply TDL `kernelparam` params for RH/Fedora ISO install (#235)

### DIFF
--- a/oz/RedHat.py
+++ b/oz/RedHat.py
@@ -108,6 +108,9 @@ Subsystem	sftp	/usr/libexec/openssh/sftp-server
         Method to modify the isolinux.cfg file on a RedHat style CD.
         """
         self.log.debug("Modifying isolinux.cfg")
+        # append additional kernel params from the TDL to initrdline
+        if self.tdl.kernel_param:
+            initrdline += " " + self.tdl.kernel_param
         isolinuxcfg = os.path.join(self.iso_contents, "isolinux",
                                    "isolinux.cfg")
 


### PR DESCRIPTION
14ad1922 added a `kernelparam` item to the TDL schema, which is
intended to allow passing extra kernel params to the installer.
It was originally handled only for 'url' type Red Hat / Fedora
installs. c623de49 made it work for Ubuntu installs. This should
also make it work for 'iso' type RH/Fedora installs. It still
will be ignored for other distros.

Resolves: https://github.com/clalancette/oz/issues/235

Signed-off-by: Adam Williamson <awilliam@redhat.com>