### PR TITLE
Initial attempt to add virtio-rng to install VM

### DIFF
--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -514,6 +514,10 @@ class Guest(object):
             self.has_consolelog = True
         else:
             self.has_consolelog = False
+        # virtio-rng
+        virtioRNG = oz.ozutil.lxml_subelement(devices, "rng", None, {'model':'virtio'})
+        virtioRNGRate = oz.ozutil.lxml_subelement(virtioRNG, "rate", None, {'bytes':'1024', 'period':'1000'})
+        virtioRNCBackend = oz.ozutil.lxml_subelement(virtioRNG, "backend", "/dev/random", {'model':'random'})
         # boot disk
         bootDisk = oz.ozutil.lxml_subelement(devices, "disk", None, {'device':'disk', 'type':'file'})
         oz.ozutil.lxml_subelement(bootDisk, "target", None, {'dev':self.disk_dev, 'bus':self.disk_bus})


### PR DESCRIPTION
F29/rawhide composes are hitting an issue where the kernel is now timing out at boot, waiting for sufficient entropy.  The hope is that allowing entropy pass-through from the host will correct this.  I'm opening this PR as a starting point.  This feature seems to have been added to libvirt quite a while ago (2012).

Reference for failed rawhide image builds: https://bugzilla.redhat.com/show_bug.cgi?id=1572916

Tested briefly on my F27 laptop installing an F27 guest.  I could see that the virtio-rng module loaded in the install guest which I _believe_ is what we want to occur.