### PR TITLE
Fix image path assertion in guest test

### DIFF
--- a/tests/guest/test_guest.py
+++ b/tests/guest/test_guest.py
@@ -348,7 +348,7 @@ def test_init_guest():
 
     assert guest.disksize == 20
     assert guest.image_name() == 'tester'
-    assert guest.output_image_path() == '/home/%s/.oz/images/tester.dsk' % getpass.getuser()
+    assert guest.output_image_path() == '%s/.oz/images/tester.dsk' % os.getenv('HOME')
     assert guest.default_auto_file() == True
 
 def test_init_guest_bad_arch():


### PR DESCRIPTION
When running the test suite via Gentoo ebuild I get the following error:
```
    def test_init_guest():                                                                                                                                                                                                                   
        guest = setup_guest(tdlxml2)                                                                    
                                                                                                                                                                                                                                             
        assert guest.disksize == 20                                                                                                                                                                                                          
        assert guest.image_name() == 'tester'                                                  
>       assert guest.output_image_path() == '/home/%s/.oz/images/tester.dsk' % getpass.getuser()                                   
E       AssertionError: assert '/var/tmp/por...es/tester.dsk' == '/home/ganto/....es/tester.dsk'                        
E         - /var/tmp/portage/app-emulation/oz-0.16.0/homedir/.oz/images/tester.dsk
E         + /home/ganto/.oz/images/tester.dsk

tests/guest/test_guest.py:352: AssertionError
```
It seems that the image is created in a home directory retrieved through the `HOME` environment variable. The test however compares it with a hard-coded value. This patch will fix this behaviour and make the test suite pass for me.