### PR TITLE
Default USB Controller and Keyboard for aarch64

### DIFF
--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -519,7 +519,7 @@ class Guest(object):
         elif self.mousetype == "usb":
             mousedict['type'] = 'tablet'
         oz.ozutil.lxml_subelement(devices, "input", None, mousedict)
-        if self.tdl.arch in ["aarch64", "armv7l"] and self.libvirt_type == "kvm":
+        if self.tdl.arch in ["aarch64", "armv7l"]:
             # Other arches add a keyboard by default, for historical reasons ARM doesn't
             # so we add it here so graphical works and hence we can get debug screenshots RHBZ 1538637
             oz.ozutil.lxml_subelement(devices, 'controller', None, {'type': 'usb', 'index': '0'})


### PR DESCRIPTION
We need the keyboard and USB Controller as well for the "qemu" libvirt type else
an error is raised:
"USB is disabled for this domain, but USB devices are present in the domain XML"

Change-Id: I8775e3f3f1ce2a0dd7dd08a6bd792c13aba3373b
Signed-off-by: Romain Forlot <romain.forlot@iot.bzh>