### PR TITLE
Set the CPU model when using aarch64 architecture

### DIFF
--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -479,6 +479,9 @@ class Guest(object):
             # Possibly related to RHBZ 1171501 - need host passthrough for aarch64 and arm with kvm
             cpu = oz.ozutil.lxml_subelement(domain, "cpu", None, {'mode': 'custom', 'match': 'exact'})
             oz.ozutil.lxml_subelement(cpu, "model", "host", {'fallback': 'allow'})
+        elif self.tdl.arch == "aarch64" and self.libvirt_type == "qemu":
+                cpu = oz.ozutil.lxml_subelement(domain, "cpu", None, {'mode': 'custom', 'match': 'exact'})
+                oz.ozutil.lxml_subelement(cpu, "model", "cortex-a57", {'fallback': 'allow'})
         # os
         osNode = oz.ozutil.lxml_subelement(domain, "os")
         mods = None


### PR DESCRIPTION
Set the CPU model when using aarch64 architecture to be able to correctly
emulate the architecture from a x86_64 platform. KVM virtualization solution
is chosen when you are running a VM using the host architecture and QEMU is
used when you are emulating another architecture than the one used by the host.

Change-Id: Icd58fad778961b99ab5a77a699ed1522e2c1ed38
Signed-off-by: Romain Forlot <romain.forlot@iot.bzh>