### PR TITLE
Explicitly require python*-rpm-macros

### DIFF
--- a/oz.spec.in
+++ b/oz.spec.in
@@ -33,6 +33,8 @@ Requires: python3-m2crypto
 Requires: python3-monotonic
 
 BuildRequires: python3
+BuildRequires: python-rpm-macros
+BuildRequires: python3-rpm-macros
 
 %description
 Oz is a set of libraries and utilities for doing automated guest OS


### PR DESCRIPTION
This change is required for a clean build in Koji.