### PR TITLE
set input devices only on non-s390x systems

### DIFF
--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -512,18 +512,19 @@ class Guest(object):
         oz.ozutil.lxml_subelement(interface, "source", None, {'bridge': self.bridge_name})
         oz.ozutil.lxml_subelement(interface, "mac", None, {'address': self.macaddr})
         oz.ozutil.lxml_subelement(interface, "model", None, {'type': self.nicmodel})
-        # input
-        mousedict = {'bus': self.mousetype}
-        if self.mousetype == "ps2":
-            mousedict['type'] = 'mouse'
-        elif self.mousetype == "usb":
-            mousedict['type'] = 'tablet'
-        oz.ozutil.lxml_subelement(devices, "input", None, mousedict)
-        if self.tdl.arch in ["aarch64", "armv7l"] and self.libvirt_type == "kvm":
-            # Other arches add a keyboard by default, for historical reasons ARM doesn't
-            # so we add it here so graphical works and hence we can get debug screenshots RHBZ 1538637
-            oz.ozutil.lxml_subelement(devices, 'controller', None, {'type': 'usb', 'index': '0'})
-            oz.ozutil.lxml_subelement(devices, 'input', None, {'type': 'keyboard', 'bus': 'usb'})
+        # input (for non-s390x only)
+        if not self.tdl.arch in ["s390x"]:
+            mousedict = {'bus': self.mousetype}
+            if self.mousetype == "ps2":
+                mousedict['type'] = 'mouse'
+            elif self.mousetype == "usb":
+                mousedict['type'] = 'tablet'
+            oz.ozutil.lxml_subelement(devices, "input", None, mousedict)
+            if self.tdl.arch in ["aarch64", "armv7l"] and self.libvirt_type == "kvm":
+                # Other arches add a keyboard by default, for historical reasons ARM doesn't
+                # so we add it here so graphical works and hence we can get debug screenshots RHBZ 1538637
+                oz.ozutil.lxml_subelement(devices, 'controller', None, {'type': 'usb', 'index': '0'})
+                oz.ozutil.lxml_subelement(devices, 'input', None, {'type': 'keyboard', 'bus': 'usb'})
         # serial console pseudo TTY
         console = oz.ozutil.lxml_subelement(devices, "serial", None, {'type': 'pty'})
         oz.ozutil.lxml_subelement(console, "target", None, {'port': '0'})


### PR DESCRIPTION
qemu/libvirt now actively rejects configuration with eg. ps2 mouse for a s390x system