### PR TITLE
Set default ssh connect timeout to 30 seconds

### DIFF
--- a/oz/Linux.py
+++ b/oz/Linux.py
@@ -81,7 +81,7 @@ class LinuxCDGuest(oz.Guest.CDGuest):
 
         return runlevel
 
-    def guest_execute_command(self, guestaddr, command, timeout=10):
+    def guest_execute_command(self, guestaddr, command, timeout=30):
         """
         Method to execute a command on the guest and return the output.
         """


### PR DESCRIPTION
In virtualized environments where hosts are shared in a build system,
it seems that a host coming online and being ready to accept commands
within the default of 10 seconds is often too short.  Increase this
to 30 seconds to reduce the number of "timeout waiting for SSH banner
exchange" errors we get while performing indirectionimage builds in
Koji.

Signed-off-by: Lon Hohberger <lon@metamorphism.com>