### PR TITLE
Fix Joliet tree sort error with Centos 8-Stream ISO

### DIFF
--- a/oz/RedHat.py
+++ b/oz/RedHat.py
@@ -89,7 +89,7 @@ Subsystem	sftp	/usr/libexec/openssh/sftp-server
         Method to create a new ISO based on the modified CD/DVD.
         """
         self.log.debug("Generating new ISO")
-        oz.ozutil.subprocess_check_output(["genisoimage", "-r", "-T", "-J",
+        oz.ozutil.subprocess_check_output(["genisoimage", "-r", "-T", "-J", "-joliet-long",
                                            "-V", "Custom", "-no-emul-boot",
                                            "-b", "isolinux/isolinux.bin",
                                            "-c", "isolinux/boot.cat",


### PR DESCRIPTION
Error:
```
genisoimage: Error: /var/lib/oz/isocontent/factory-build-244d0db5-0be5-4948-b20a-d4eaf74b814e-iso/AppStream/Packages/clang-resource-filesystem-13.0.0-2.module_el8.6.0+1029+6594c364.i686.rpm and /var/lib/oz/isocontent/factory-build-244d0db5-0be5-4948-b20a-d4eaf74b814e-iso/AppStream/Packages/clang-resource-filesystem-13.0.0-2.module_el8.6.0+1029+6594c364.x86_64.rpm have the same Joliet name
    Joliet tree sort failed. The -joliet-long switch may help you.
```
Fixes: https://github.com/ManageIQ/manageiq-appliance-build/pull/500