### PR TITLE
ozutil: collections -> collections.abc

### DIFF
--- a/oz/ozutil.py
+++ b/oz/ozutil.py
@@ -19,7 +19,7 @@
 Miscellaneous utility functions.
 """
 
-import collections
+import collections.abc
 try:
     import configparser
 except ImportError:
@@ -536,7 +536,7 @@ def copy_modify_file(inname, outname, subfunc):
         raise Exception("output filename is None")
     if subfunc is None:
         raise Exception("subfunction is None")
-    if not isinstance(subfunc, collections.Callable):
+    if not isinstance(subfunc, collections.abc.Callable):
         raise Exception("subfunction is not callable")
 
     infile = open(inname, 'r')


### PR DESCRIPTION
For python 3.10, some items formerly from collections must now be
obtained from collections.abc.  This should be backwards compatible.
https://docs.python.org/3.5/library/collections.abc.html#collections.abc.Callable