### PR TITLE
Enable USB controller and keyboard for aarch64 for all libvirt types

### DIFF
--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -531,7 +531,7 @@ class Guest(object):
             elif self.mousetype == "usb":
                 mousedict['type'] = 'tablet'
             oz.ozutil.lxml_subelement(devices, "input", None, mousedict)
-            if self.tdl.arch in ["aarch64", "armv7l"] and self.libvirt_type == "kvm":
+            if self.tdl.arch in ["aarch64", "armv7l"]:
                 # Other arches add a keyboard by default, for historical reasons ARM doesn't
                 # so we add it here so graphical works and hence we can get debug screenshots RHBZ 1538637
                 oz.ozutil.lxml_subelement(devices, 'controller', None, {'type': 'usb', 'index': '0'})


### PR DESCRIPTION
This is @[claneys](https://github.com/claneys)'s PR #271, but hopefully with a more acceptable commit message this time. This PR is still needed to be able to build aarch64 images with qemu.