### PR TITLE
Change mousetype to usb for ppc64le

### DIFF
--- a/oz/Guest.py
+++ b/oz/Guest.py
@@ -259,7 +259,7 @@ class Guest(object):
             self.clockoffset = "utc"
         self.mousetype = mousetype
         if self.mousetype is None:
-            if self.tdl.arch in ["aarch64", "armv7l"]:
+            if self.tdl.arch in ["aarch64", "armv7l", "ppc64le"]:
                 self.mousetype = "usb"
             else:
                 self.mousetype = "ps2"


### PR DESCRIPTION
When running on ppc64le, I encountered an issue where qemu is not configured with the ps2 driver, and instead needs the usb one.

I am not sure whether this change has impact other places, so I am opening this PR to discuss.