### PR TITLE
Don't write kickstart so initial-setup won't think root pw is set

### DIFF
--- a/oz/Fedora.py
+++ b/oz/Fedora.py
@@ -293,6 +293,10 @@ class FedoraGuest(oz.RedHat.RedHatLinuxCDYumGuest):
             # out the method completely
             if not self.config.brokenisomethod:
                 initrdline += " inst.method=cdrom:/dev/cdrom"
+        # don't write the kickstart to the image, or else initial-setup
+        # will think a root password has been set:
+        # https://bugzilla.redhat.com/show_bug.cgi?id=2015490
+        initrdline += " inst.nosave=output_ks"
         self._modify_isolinux(initrdline)
 
     def generate_diskimage(self, size=10, force=False):

--- a/oz/RedHat.py
+++ b/oz/RedHat.py
@@ -79,6 +79,10 @@ Subsystem	sftp	/usr/libexec/openssh/sftp-server
                                         self.tdl.distro + self.tdl.update + self.tdl.arch + "-ramdisk")
 
         self.cmdline = "inst.method=" + self.url + " inst.ks=file:/ks.cfg"
+        # don't write the kickstart to the image, or else initial-setup
+        # will think a root password has been set:
+        # https://bugzilla.redhat.com/show_bug.cgi?id=2015490
+        self.cmdline += " inst.nosave=output_ks"
         if self.tdl.kernel_param:
             self.cmdline += " " + self.tdl.kernel_param
 


### PR DESCRIPTION
We previously landed this as https://github.com/clalancette/oz/commit/ef55a6402143f810b7c221c2763b7eb52b4b8261 but then had to [revert it because the changes to initial-setup weren't done](https://github.com/clalancette/oz/pull/297). Per [this comment on the original bug report](https://bugzilla.redhat.com/show_bug.cgi?id=2015490#c25), the changes in initial-setup *are* done now, so it should be OK to put this back.

I do have one concern about whether we need the change to initial-setup in F37 as well, but that doesn't need to hold up merging this upstream, I don't think.