### PR TITLE
tests: mock network functions so tests work with no network

### DIFF
--- a/README
+++ b/README
@@ -28,7 +28,7 @@ dnf install python3-requests python3-cryptography python3-libvirt python3-lxml p
 
 If you wish to test on EL 7, make that:
 
-yum install python-requests python-cryptography libvirt-python python-lxml python-libguestfs pytest python-monotonic
+yum install python-requests python-cryptography libvirt-python python-lxml python-libguestfs pytest python-monotonic python-mock
 
 then run the tests:
 

--- a/tests/guest/test_guest.py
+++ b/tests/guest/test_guest.py
@@ -12,6 +12,10 @@ except:
     from io import StringIO
 import logging
 import os
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 # Find oz library
 prefix = '.'
@@ -72,7 +76,10 @@ def setup_guest(xml, macaddress=None):
         config = configparser.ConfigParser()
         config.read_file(StringIO("[libvirt]\nuri=qemu:///session\nbridge_name=%s" % route))
 
-    guest = oz.GuestFactory.guest_factory(tdl, config, None, macaddress=macaddress)
+    # mock this - it's used in RedHatLinuxCDYumGuest._check_url() -
+    # so the tests can run without a network connection
+    with mock.patch("oz.ozutil.http_get_header", return_value={}):
+        guest = oz.GuestFactory.guest_factory(tdl, config, None, macaddress=macaddress)
     return guest
 
 tdlxml = """

--- a/tests/tdl/test_tdl.py
+++ b/tests/tdl/test_tdl.py
@@ -2,6 +2,10 @@
 
 import sys
 import os
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 try:
     import lxml.etree
@@ -100,7 +104,8 @@ tests = {
 }
 
 # Test that iterates over all .tdl files
-def test_all():
+@mock.patch("oz.ozutil.http_download_file")
+def test_all(fakedl):
     for (tdl, expected_pass) in list(tests.items()):
 
         # locate full path for tdl file


### PR DESCRIPTION
Noticed this while trying to enable the tests in a package build.