### PR TITLE
Replace M2Crypto with cryptography

### DIFF
--- a/Containerfile.tests.el7
+++ b/Containerfile.tests.el7
@@ -4,7 +4,7 @@
 FROM quay.io/centos/centos:7
 RUN set -exo pipefail \
     && yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
-    && yum install -y python-requests m2crypto libvirt-python python-lxml python-libguestfs pytest python-monotonic libvirt \
+    && yum install -y python-requests python-cryptography libvirt-python python-lxml python-libguestfs pytest python-monotonic libvirt \
     && yum clean all \
     && rm -rf /var/cache/* /var/log/yum*
 

--- a/Containerfile.tests.fedora
+++ b/Containerfile.tests.fedora
@@ -4,7 +4,7 @@
 FROM quay.io/fedora/fedora:latest
 RUN set -exo pipefail \
     && dnf install -y --setopt install_weak_deps=false --nodocs \
-    python3-requests python3-m2crypto python3-setuptools python3-libvirt python3-lxml python3-libguestfs python3-pytest python3-monotonic \
+    python3-requests python3-cryptography python3-setuptools python3-libvirt python3-lxml python3-libguestfs python3-pytest python3-monotonic \
     libvirt-daemon libvirt-daemon-kvm libvirt-daemon-qemu libvirt-daemon-config-network systemd \
     && dnf clean all \
     && rm -rf /var/cache/* /var/log/dnf*

--- a/README
+++ b/README
@@ -24,11 +24,11 @@ guestfs Python module, which is not available from pypi, and needs a running
 libvirtd for most of the tests to run. To install all the test requirements on
 Fedora:
 
-dnf install python3-requests python3-m2crypto python3-libvirt python3-lxml python3-libguestfs python3-pytest python3-monotonic
+dnf install python3-requests python3-cryptography python3-libvirt python3-lxml python3-libguestfs python3-pytest python3-monotonic
 
 If you wish to test on EL 7, make that:
 
-yum install python-requests m2crypto libvirt-python python-lxml python-libguestfs pytest python-monotonic
+yum install python-requests python-cryptography libvirt-python python-lxml python-libguestfs pytest python-monotonic
 
 then run the tests:
 
@@ -37,7 +37,7 @@ py.test tests/
 You can try `make virtualenv` then `make unittests` to run the tests in a
 virtualenv if you like, but this still requires at least the libguestfs library
 installed on the host, and a running libvirtd. You may also want to install
-m2crypto and libvirt libraries on the host, as otherwise pip will have to
+cryptography and libvirt libraries on the host, as otherwise pip will have to
 compile them, and you'll need their build dependencies.
 
 You can use `make pylint` and `make flake8` to run lint checks.

--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,7 @@ Depends: ${misc:Depends}, ${python:Depends},
  python-lxml,
  python-libvirt (>= 0.9.7),
  python-requests,
- python-m2crypto,
+ python-cryptography,
  python-monotonic,
 Description: installing guest OSs with only minimal input the user
  Oz is a tool for automatically installing guest OSs with only minimal

--- a/oz.spec.in
+++ b/oz.spec.in
@@ -16,7 +16,7 @@ Requires: python3
 Requires: python3-lxml
 Requires: python3-libguestfs >= 1.18
 Requires: python3-libvirt
-Requires: python3-m2crypto
+Requires: python3-cryptography
 Requires: python3-monotonic
 Requires: python3-requests
 # in theory, oz doesn't really require libvirtd to be local to operate

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
-m2crypto
+cryptography
 libvirt-python
 lxml
 monotonic


### PR DESCRIPTION
M2Crypto is in maintainenance mode now. The project recommends replacing it with cryptography, which this pull request implements.